### PR TITLE
Firewall rule enhancements

### DIFF
--- a/pfSense-pkg-API/files/etc/inc/api/framework/APIResponse.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/framework/APIResponse.inc
@@ -1544,6 +1544,12 @@ function get($id, $data=[], $all=false) {
             "return" => $id,
             "message" => "Firewall alias cannot be deleted while in use"
         ],
+        4109 => [
+            "status" => "bad request",
+            "code" => 400,
+            "return" => $id,
+            "message" => "Firewall rule gateway must match IP protocol"
+        ],
 
         //5000-5999 reserved for /users API calls
         5000 => [

--- a/pfSense-pkg-API/files/etc/inc/api/framework/APITools.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/framework/APITools.inc
@@ -521,22 +521,28 @@ function sort_firewall_rules($mode=null, $data=null) {
     $config["filter"]["rule"] = $master_arr;
 }
 
-// Checks if inputted routing gateway exists
-function is_gateway($gw) {
-    // Local variables
-    $gw_config = return_gateways_array(true, true);
-    $gw_exists = false;
-    // Check that we have gateways configured
+# Checks if routing gateway exists
+function is_gateway($gw, $ret_protocol=false) {
+    # Local variables
+    $gw_config = return_gateways_array();
+    $gw_group_config = return_gateway_groups_array();
+
+    # Loop through each gateway/gateway group and check if our gw matches the name
     if (is_array($gw_config)) {
-        // Loop through each gateway and see if name matches
+        # Loop through each gateway and see if name matches
         foreach ($gw_config as $gw_name => $gw_item) {
             if ($gw === $gw_name) {
-                $gw_exists = true;
-                break;
+                return ($ret_protocol) ? $gw_item["ipprotocol"] : true;
+            }
+        }
+        # Loop through each gateway and see if name matches
+        foreach ($gw_group_config as $gwg_name => $gwg_item) {
+            if ($gw === $gwg_name) {
+                return ($ret_protocol) ? $gwg_item["ipprotocol"] : true;
             }
         }
     }
-    return $gw_exists;
+    return false;
 }
 
 // Duplicate function from /firewall_aliases.php: accept input and check if alias exists

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallRuleCreate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallRuleCreate.inc
@@ -195,7 +195,7 @@ class APIFirewallRuleCreate extends APIModel {
                 $this->errors[] = APIResponse\get(4043);
             }
             # Check if the gateway IP protocol matches our rule's IP protocol
-            elseif ($gw_protocol !== "inet46" and $gw_protocol !== $this->validated_data["ipprotocol"]) {
+            elseif ($gw_protocol !== $this->validated_data["ipprotocol"]) {
                 $this->errors[] = APIResponse\get(4109);
             }
             # Otherwise, the gateway is valid

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallRuleCreate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallRuleCreate.inc
@@ -33,10 +33,7 @@ class APIFirewallRuleCreate extends APIModel {
         return APIResponse\get(0, $this->validated_data);
     }
 
-    public function validate_payload() {
-        # Include static rule ID
-        $this->validated_data["id"] = "";
-
+    private function __validate_type() {
         # Check for our required 'type' payload value
         if (isset($this->initial_data["type"])) {
             $type_options = array("pass", "block", "reject");
@@ -49,7 +46,9 @@ class APIFirewallRuleCreate extends APIModel {
         } else {
             $this->errors[] = APIResponse\get(4033);
         }
+    }
 
+    private function __validate_interface() {
         # Check for our required 'interface' payload value
         if (isset($this->initial_data['interface'])) {
             $this->initial_data['interface'] = APITools\get_pfsense_if_id($this->initial_data['interface']);
@@ -62,7 +61,9 @@ class APIFirewallRuleCreate extends APIModel {
         } else {
             $this->errors[] = APIResponse\get(4034);
         }
+    }
 
+    private function __validate_ipprotocol() {
         # Check for our required 'ipprotocol' payload value
         if (isset($this->initial_data['ipprotocol'])) {
             $ipprotocol_options = array("inet", "inet6", "inet46");
@@ -75,7 +76,9 @@ class APIFirewallRuleCreate extends APIModel {
         } else {
             $this->errors[] = APIResponse\get(4035);
         }
+    }
 
+    private function __validate_protocol() {
         # Check for our required 'protocol' payload value
         if (isset($this->initial_data['protocol'])) {
             $protocol_options = [
@@ -91,11 +94,12 @@ class APIFirewallRuleCreate extends APIModel {
             } else {
                 $this->errors[] = APIResponse\get(4042);
             }
-            $protocol = $this->initial_data['protocol'];
         } else {
             $this->errors[] = APIResponse\get(4036);
         }
+    }
 
+    private function __validate_icmptype() {
         # Check for our optional 'icmpsubtype' payload value when our protocol is set to ICMP
         if (isset($this->initial_data["icmptype"]) and $this->validated_data["protocol"] === "icmp") {
             $icmptype_options = [
@@ -118,7 +122,9 @@ class APIFirewallRuleCreate extends APIModel {
                 $this->validated_data["icmptype"] = implode(",", $this->initial_data["icmptype"]);
             }
         }
+    }
 
+    private function __validate_src() {
         # Check for our required 'src' payload value
         if (isset($this->initial_data['src'])) {
             // Check if our source and destination values are valid
@@ -131,7 +137,9 @@ class APIFirewallRuleCreate extends APIModel {
         } else {
             $this->errors[] = APIResponse\get(4037);
         }
+    }
 
+    private function __validate_dst() {
         # Check for our required 'src' payload value
         if (isset($this->initial_data['dst'])) {
             // Check if our source and destination values are valid
@@ -144,8 +152,10 @@ class APIFirewallRuleCreate extends APIModel {
         } else {
             $this->errors[] = APIResponse\get(4038);
         }
+    }
 
-        # Check for our required 'srcport' and 'dstport' payload values if protocol is TCP, UDP or TCP/UDP
+    private function __validate_srcport() {
+        # Check for our required 'srcport' payload values if protocol is TCP, UDP or TCP/UDP
         if (in_array($this->validated_data["protocol"], ["tcp", "udp", "tcp/udp"])) {
             if (isset($this->initial_data['srcport'])) {
                 $val = str_replace("-", ":", $this->initial_data['srcport']);
@@ -157,7 +167,12 @@ class APIFirewallRuleCreate extends APIModel {
             } else {
                 $this->errors[] = APIResponse\get(4047);
             }
+        }
+    }
 
+    private function __validate_dstport() {
+        # Check for our required 'dstport' payload values if protocol is TCP, UDP or TCP/UDP
+        if (in_array($this->validated_data["protocol"], ["tcp", "udp", "tcp/udp"])) {
             if (isset($this->initial_data['dstport'])) {
                 $val = str_replace("-", ":", $this->initial_data['dstport']);
                 if (!is_port_or_range_or_alias($val) and $val !== "any") {
@@ -169,37 +184,70 @@ class APIFirewallRuleCreate extends APIModel {
                 $this->errors[] = APIResponse\get(4047);
             }
         }
+    }
 
+    private function __validate_gateway() {
         # Check for our optional 'gateway' payload value
         if (isset($this->initial_data['gateway'])) {
-            # Check that the specified gateway exists
-            if (APITools\is_gateway($this->initial_data["gateway"])) {
-                $this->validated_data["gateway"] = $this->initial_data["gateway"];
-            } else {
+            $gw_protocol = APITools\is_gateway($this->initial_data["gateway"], true);
+            # Check if we were able to locate the gateway
+            if ($gw_protocol === false) {
                 $this->errors[] = APIResponse\get(4043);
             }
+            # Check if the gateway IP protocol matches our rule's IP protocol
+            elseif ($gw_protocol !== "inet46" and $gw_protocol !== $this->validated_data["ipprotocol"]) {
+                $this->errors[] = APIResponse\get(4109);
+            }
+            # Otherwise, the gateway is valid
+            else {
+                $this->validated_data["gateway"] = $this->initial_data["gateway"];
+            }
         }
+    }
 
-
+    private function __validate_disabled() {
         # Check for our optional 'disabled' payload value
         if ($this->initial_data['disabled'] === true) {
             $this->validated_data["disabled"] = "";
         }
+    }
 
+    private function __validate_descr() {
         # Check for our optional 'descr' payload value
         if (isset($this->initial_data['descr'])) {
             $this->validated_data["descr"] = strval($this->initial_data['descr']);
         }
+    }
 
+    private function __validate_log() {
         # Check for our optional 'log' payload value
         if ($this->initial_data['log'] === true) {
             $this->validated_data["log"] = "";
         }
+    }
 
+    private function __validate_top() {
         # Check for our optional 'top' payload value
         if ($this->initial_data['top'] === true) {
             $this->initial_data['top'] = "top";
         }
+    }
+
+    public function validate_payload() {
+        $this->__validate_type();
+        $this->__validate_interface();
+        $this->__validate_ipprotocol();
+        $this->__validate_protocol();
+        $this->__validate_icmptype();
+        $this->__validate_src();
+        $this->__validate_dst();
+        $this->__validate_srcport();
+        $this->__validate_dstport();
+        $this->__validate_gateway();
+        $this->__validate_disabled();
+        $this->__validate_descr();
+        $this->__validate_log();
+        $this->__validate_top();
 
         # Add our static 'tracker', 'created' and 'updated' values
         $this->validated_data["tracker"] = (int)microtime(true);

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallRuleUpdate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallRuleUpdate.inc
@@ -218,7 +218,7 @@ class APIFirewallRuleUpdate extends APIModel {
                 $this->errors[] = APIResponse\get(4043);
             }
             # Check if the gateway IP protocol matches our rule's IP protocol
-            elseif ($gw_protocol !== "inet46" and $gw_protocol !== $this->validated_data["ipprotocol"]) {
+            elseif ($gw_protocol !== $this->validated_data["ipprotocol"]) {
                 $this->errors[] = APIResponse\get(4109);
             }
             # Otherwise, the gateway is valid

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallRuleUpdate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallRuleUpdate.inc
@@ -17,11 +17,16 @@ require_once("api/framework/APIModel.inc");
 require_once("api/framework/APIResponse.inc");
 
 class APIFirewallRuleUpdate extends APIModel {
+    private $requires_port;
+    private $missing_port;
+
     # Create our method constructor
     public function __construct() {
         parent::__construct();
         $this->privileges = ["page-all", "page-firewall-rules-edit"];
         $this->change_note = "Modified firewall rule via API";
+        $this->requires_port = false;
+        $this->missing_port = false;
     }
 
     public function action() {
@@ -33,7 +38,7 @@ class APIFirewallRuleUpdate extends APIModel {
         return APIResponse\get(0, $this->validated_data);
     }
 
-    public function validate_payload() {
+    private function __validate_tracker() {
         # Check for our required 'tracker' payload value
         if (isset($this->initial_data['tracker'])) {
             # Loop through each rule and check if our tracker matches
@@ -51,7 +56,9 @@ class APIFirewallRuleUpdate extends APIModel {
         } else {
             $this->errors[] = APIResponse\get(4031);
         }
+    }
 
+    private function __validate_type() {
         # Check for our optional 'type' payload value
         if (isset($this->initial_data["type"])) {
             $type_options = array("pass", "block", "reject");
@@ -62,7 +69,9 @@ class APIFirewallRuleUpdate extends APIModel {
                 $this->errors[] = APIResponse\get(4039);
             }
         }
+    }
 
+    private function __validate_interface() {
         # Check for our optional 'interface' payload value
         if (isset($this->initial_data['interface'])) {
             $this->initial_data['interface'] = APITools\get_pfsense_if_id($this->initial_data['interface']);
@@ -73,7 +82,9 @@ class APIFirewallRuleUpdate extends APIModel {
                 $this->errors[] = APIResponse\get(4034);
             }
         }
+    }
 
+    private function __validate_ipprotocol() {
         # Check for our optional 'ipprotocol' payload value
         if (isset($this->initial_data['ipprotocol'])) {
             $ipprotocol_options = array("inet", "inet6", "inet46");
@@ -84,11 +95,13 @@ class APIFirewallRuleUpdate extends APIModel {
                 $this->errors[] = APIResponse\get(4041);
             }
         }
+    }
 
+    private function __validate_protocol() {
         # Check for our optional 'protocol' payload value
         if (isset($this->initial_data['protocol'])) {
-            $missing_port = (!in_array($this->validated_data["protocol"], ["tcp", "udp", "tcp/udp"])) ? true : false;
-            $requires_port = (in_array($this->initial_data["protocol"], ["tcp", "udp", "tcp/udp"])) ? true : false;
+            $this->missing_port = (!in_array($this->validated_data["protocol"], ["tcp", "udp", "tcp/udp"])) ? true : false;
+            $this->requires_port = (in_array($this->initial_data["protocol"], ["tcp", "udp", "tcp/udp"])) ? true : false;
             $this->unset_ports();
             $protocol_options = [
                 "any", "tcp", "udp", "tcp/udp", "icmp", "esp", "ah",
@@ -106,12 +119,10 @@ class APIFirewallRuleUpdate extends APIModel {
             } else {
                 $this->errors[] = APIResponse\get(4042);
             }
-        } else {
-            # If a new protocol was not selected don't validate ports
-            $requires_port = false;
-            $missing_port = false;
         }
+    }
 
+    private function __validate_icmptype() {
         # Check for our optional 'icmpsubtype' payload value when our protocol is set to ICMP
         if (isset($this->initial_data["icmptype"]) and $this->validated_data["protocol"] === "icmp") {
             $icmptype_options = [
@@ -125,19 +136,21 @@ class APIFirewallRuleUpdate extends APIModel {
                 $this->initial_data["icmptype"] = array($this->initial_data["icmptype"]);
             }
 
-            // Loop through each of our subtypes
+            # Loop through each of our subtypes
             foreach ($this->initial_data["icmptype"] as $ict) {
                 if (!in_array($ict, $icmptype_options)) {
                     $this->errors[] = APIResponse\get(4046);
                 }
-                // Write our ICMP subtype config
+                # Write our ICMP subtype config
                 $this->validated_data["icmptype"] = implode(",", $this->initial_data["icmptype"]);
             }
         }
+    }
 
+    private function __validate_src() {
         # Check for our optional 'src' payload value
         if (isset($this->initial_data['src'])) {
-            // Check if our source and destination values are valid
+            # Check if our source and destination values are valid
             $dir_check = APITools\is_valid_rule_addr($this->initial_data['src'], "source");
             if ($dir_check["valid"] === true) {
                 $this->validated_data = array_merge($this->validated_data, $dir_check["data"]);
@@ -145,10 +158,12 @@ class APIFirewallRuleUpdate extends APIModel {
                 $this->errors[] = APIResponse\get(4044);
             }
         }
+    }
 
+    private function __validate_dst() {
         # Check for our optional 'src' payload value
         if (isset($this->initial_data['dst'])) {
-            // Check if our source and destination values are valid
+            # Check if our source and destination values are valid
             $dir_check = APITools\is_valid_rule_addr($this->initial_data['dst'], "destination");
             if ($dir_check["valid"] === true) {
                 $this->validated_data = array_merge($this->validated_data, $dir_check["data"]);
@@ -156,9 +171,11 @@ class APIFirewallRuleUpdate extends APIModel {
                 $this->errors[] = APIResponse\get(4049);
             }
         }
+    }
 
-        # Check for our optional 'srcport' and 'dstport' payload values if protocol is TCP, UDP or TCP/UDP
-        if ($requires_port) {
+    private function __validate_srcport() {
+        # Check for our optional 'srcport' payload values if protocol is TCP, UDP or TCP/UDP
+        if ($this->requires_port) {
             if (isset($this->initial_data['srcport'])) {
                 $val = str_replace("-", ":", $this->initial_data['srcport']);
                 if (!is_port_or_range_or_alias($val) and $val !== "any") {
@@ -166,10 +183,15 @@ class APIFirewallRuleUpdate extends APIModel {
                 } elseif ($val !== "any") {
                     $this->validated_data["source"]["port"] = str_replace(":", "-", $val);;
                 }
-            } elseif ($missing_port) {
+            } elseif ($this->missing_port) {
                 $this->errors[] = APIResponse\get(4047);
             }
+        }
+    }
 
+    private function __validate_dstport() {
+        # Check for our optional 'dstport' payload values if protocol is TCP, UDP or TCP/UDP
+        if ($this->requires_port) {
             if (isset($this->initial_data['dstport'])) {
                 $val = str_replace("-", ":", $this->initial_data['dstport']);
                 if (!is_port_or_range_or_alias($val) and $val !== "any") {
@@ -177,42 +199,83 @@ class APIFirewallRuleUpdate extends APIModel {
                 } elseif ($val !== "any") {
                     $this->validated_data["destination"]["port"] = str_replace(":", "-", $val);;
                 }
-            } elseif ($missing_port) {
+            } elseif ($this->missing_port) {
                 $this->errors[] = APIResponse\get(4047);
             }
         }
+    }
 
-        # Check for our optional 'gateway' payload value
-        if (isset($this->initial_data['gateway'])) {
-            # Check that the specified gateway exists
-            if (APITools\is_gateway($this->initial_data["gateway"])) {
-                $this->validated_data["gateway"] = $this->initial_data["gateway"];
-            } else {
+    private function __validate_gateway() {
+        # Check for our optional 'gateway' payload value. If already set, revalidate.
+        if (isset($this->initial_data['gateway']) or isset($this->validated_data['gateway'])) {
+            # Revalidate the existing value if a new one was not specified
+            if (!isset($this->initial_data["gateway"])) {
+                $this->initial_data["gateway"] = $this->validated_data["gateway"];
+            }
+            $gw_protocol = APITools\is_gateway($this->initial_data["gateway"], true);
+            # Check if we were able to locate the gateway
+            if ($gw_protocol === false) {
                 $this->errors[] = APIResponse\get(4043);
             }
+            # Check if the gateway IP protocol matches our rule's IP protocol
+            elseif ($gw_protocol !== "inet46" and $gw_protocol !== $this->validated_data["ipprotocol"]) {
+                $this->errors[] = APIResponse\get(4109);
+            }
+            # Otherwise, the gateway is valid
+            else {
+                $this->validated_data["gateway"] = $this->initial_data["gateway"];
+            }
         }
+    }
 
+    private function __validate_disabled() {
         # Check for our optional 'disabled' payload value
         if ($this->initial_data['disabled'] === true) {
             $this->validated_data["disabled"] = "";
         } elseif ($this->initial_data['disabled'] === false) {
             unset($this->validated_data["disabled"]);
         }
+    }
 
+    private function __validate_descr() {
         # Check for our optional 'descr' payload value
         if (isset($this->initial_data['descr'])) {
             $this->validated_data["descr"] = strval($this->initial_data['descr']);
         }
+    }
 
+    private function __validate_log() {
         # Check for our optional 'log' payload value
         if ($this->initial_data['log'] === true) {
             $this->validated_data["log"] = "";
+        } elseif ($this->initial_data['log'] === false) {
+            unset($this->validated_data["log"]);
         }
+    }
 
+    private function __validate_top() {
         # Check for our optional 'top' payload value
         if ($this->initial_data['top'] === true) {
             $this->initial_data['top'] = "top";
         }
+    }
+
+    public function validate_payload() {
+        $this->__validate_tracker();
+        $this->__validate_type();
+        $this->__validate_interface();
+        $this->__validate_ipprotocol();
+        $this->__validate_protocol();
+        $this->__validate_icmptype();
+        $this->__validate_src();
+        $this->__validate_dst();
+        $this->__validate_srcport();
+        $this->__validate_dstport();
+        $this->__validate_gateway();
+        $this->__validate_disabled();
+        $this->__validate_descr();
+        $this->__validate_log();
+        $this->__validate_top();
 
         # Update our 'updated' value
         $this->validated_data["updated"] = [

--- a/tests/test_api_v1_firewall_rule.py
+++ b/tests/test_api_v1_firewall_rule.py
@@ -28,6 +28,7 @@ class APIUnitTestFirewallRule(unit_test_framework.APIUnitTest):
             "dst": "127.0.0.1",
             "dstport": "443",
             "descr": "Unit test",
+            "log": True,
             "top": True
         }
     ]
@@ -38,10 +39,12 @@ class APIUnitTestFirewallRule(unit_test_framework.APIUnitTest):
             "ipprotocol": "inet",
             "protocol": "tcp/udp",
             "src": "172.16.77.125",
-            "srcport": "HTTP",
+            "srcport": "8080-8081",
             "dst": "127.0.0.1",
-            "dstport": "HTTP",
+            "dstport": "2222-4444",
             "descr": "Updated Unit test",
+            "gateway": "WAN_DHCP",
+            "log": False,
             "top": True
         }
     ]


### PR DESCRIPTION
- Allows clients to create/update firewall rules with a gateway group in the `gateway` field.
- Adds validation to only allow clients to set a firewall rule's `gateway` field if the IP protocol of the rule object matches the gateway's IP protocol value.
- Fixes bug that prevented clients from updating the `log` field on firewall rules.
- Fixes bug that allowed clients to create/update gateway objects that use an existing gateway group name.
- Breaks down firewall rule validation to smaller and easier to understand methods.
- Fixes bad PUT payload value in `test_api_v1_firewall_rule.py` unit test.