### PR TITLE
Firewall States Parsing Fix

### DIFF
--- a/pfSense-pkg-API/files/etc/inc/api/framework/APITools.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/framework/APITools.inc
@@ -623,28 +623,6 @@ function sanitize_str($string) {
     return $string;
 }
 
-// Sort our state table
-function sort_state_table() {
-    // Local variables
-    $states = shell_exec("/sbin/pfctl -s state");
-    $state_table = array();
-    // Parse our output
-    $state_rows = explode("\n", $states);
-    foreach ($state_rows as $id => $data) {
-        $data = preg_replace('!\s+!', ' ', $data);    // Remove extra whitespace
-        $data_fields = explode(" ", $data);    // Split on whitespace
-        if (count($data_fields) > 1) {
-            $state_table[$id] = array();
-            $state_table[$id]["interface"] = $data_fields[0];
-            $state_table[$id]["protocol"] = $data_fields[1];
-            $state_table[$id]["source"] = ($data_fields[3] === "->") ? $data_fields[2] : $data_fields[4];
-            $state_table[$id]["destination"] = ($data_fields[3] === "->") ? $data_fields[4] : $data_fields[2];
-            $state_table[$id]["status"] = $data_fields[5];
-        }
-    }
-    return $state_table;
-}
-
 // Restarts the pfSense webConfigurator
 function restart_webconfigurator() {
     ob_flush();

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallStatesRead.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallStatesRead.inc
@@ -25,6 +25,27 @@ class APIFirewallStatesRead extends APIModel {
     }
 
     public function action() {
-        return APIResponse\get(0, APITools\sort_state_table());
+        return APIResponse\get(0, $this->get_state_table());
+    }
+
+    public static function get_state_table() {
+        $raw_table = pfSense_get_pf_states();
+        return array_map(function($table) {
+            return array(
+                'interface' => $table['if'],
+                'protocol' => $table['proto'],
+                'source' => $table['src'],
+                'destination' => $table['dst'],
+                'status' => $table["state"],
+                'age' => $table["age"],
+                "expires_in" => $table["expires in"],
+                "packets_total" => $table["packets total"],
+                "packets_in" => $table["packets in"],
+                "packets_out" => $table["packets out"],
+                "bytes_total" => $table["bytes total"],
+                "bytes_in" => $table["bytes in"],
+                "bytes_out" => $table["bytes out"],
+            );
+        }, $raw_table);
     }
 }

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallStatesSizeRead.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallStatesSizeRead.inc
@@ -25,16 +25,15 @@ class APIFirewallStatesSizeRead extends APIModel {
     }
 
     public function action() {
-
-        // Check our maximum state table size
+        # Check our maximum state table size
         if (isset($this->config["system"]["maximumstates"])) {
             $size_array["maximumstates"] = intval($this->config["system"]["maximumstates"]);
         } else {
             $size_array["maximumstates"] = intval(pfsense_default_state_size());
         }
-        // Check our current state table size
-        $size_array["currentstates"] = count(APITools\sort_state_table());
-        // Check our default state table size
+        # Check our current state table size
+        $size_array["currentstates"] = count(APIFirewallStatesRead::get_state_table());
+        # Check our default state table size
         $size_array["defaultmaximumstates"] = intval(pfsense_default_state_size());
         return APIResponse\get(0, $size_array);
     }


### PR DESCRIPTION
- Fixes parsing bug in APIFirewallStatesRead.inc that prevented the firewall states table from being parsed correctly on some interfaces
- Adds the `age`, `expires_in`, `packets_total`, `packets_in`, `packets_out`, `bytes_total`, `bytes_in`, and `bytes_out` field to returned firewall states