### PR TITLE
API requests via virtual IP

### DIFF
--- a/pfSense-pkg-API/files/etc/inc/api/framework/APIModel.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/framework/APIModel.inc
@@ -141,17 +141,17 @@ class APIModel {
         $allow_ifs = $pkg_conf["allowed_interfaces"];
         $whitelist = explode(",", $allow_ifs);
 
-        // Check if our server IP is in our whitelist
+        # Check if our server IP is in our whitelist
         foreach ($whitelist as $wif) {
             $if_info = get_interface_info($wif);
-            // Check if our server IP is a valid if address, localhost, or any
-            if ($_SERVER["SERVER_ADDR"] === $if_info["ipaddr"]) {
+            # Check if our server IP is a valid if address, VIP, localhost, or any
+            if ($_SERVER["SERVER_ADDR"] === $if_info["ipaddr"] or APITools\is_ip_vip($_SERVER["SERVER_ADDR"], $wif)) {
                 return;
             } elseif ($_SERVER["SERVER_ADDR"] === $if_info["ipaddrv6"]) {
                 return;
             } elseif (in_array($_SERVER["SERVER_ADDR"], ["::1", "127.0.0.1", "localhost"]) and $wif === "localhost") {
                 return;
-            }elseif ($wif === "any") {
+            } elseif ($wif === "any") {
                 return;
             }
         }

--- a/pfSense-pkg-API/files/etc/inc/api/framework/APITools.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/framework/APITools.inc
@@ -1050,6 +1050,35 @@ function is_ip_subnet_or_alias($value) {
     }
 }
 
+# Checks if a given IP is within a given CIDR
+function is_ip_in_cidr($ip, $cidr) {
+    # Use IP2Long to determine if a specified IP is within a specified cidr
+    $subnet = explode('/', $cidr)[0];
+    $subnet = ip2long($subnet);
+    $bits = (!is_null(explode('/', $cidr)[1])) ? explode('/', $cidr)[1] : 32;
+    $ip = ip2long($ip);
+    $mask = -1 << (32 - $bits);
+    $subnet &= $mask;
+    return ($ip & $mask) == $subnet;
+}
+
+# Check if a specified IP is a configured virtual IP
+function is_ip_vip($ip, $if=null) {
+    global $config;
+
+    # Loop through each configured virtual IP
+    foreach ($config["virtualip"]["vip"] as $vip) {
+        # Check if this VIPs interface matches the requested interface, or any if none was specified
+        if ($vip["interface"] === $if or $if === null) {
+            # Check if the specified IP is contained in this VIP
+            if (is_ip_in_cidr($ip, $vip["subnet"]."/".$vip["subnet_bits"])) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 # Checks if an array is a associative array. Returns true if assoc, false if numeric, or null if not array
 function is_assoc_array($array, $strict_seq=false) {
     # Local variables


### PR DESCRIPTION
- Allows virtual IPs to respond to API requests when the virtual IPs interface matches the `allowed_interfaces` API setting (IPv4 CARP or IP Alias virtual IPs only)
- Adds `is_ip_vip()` function to check if a provided IP is a configured virtual IP on the system
- Adds `is_ip_in_cidr()` function to check if provided IP is within a provide CIDR