### PR TITLE
 Fix track6-prefix-id on interface create/update

### DIFF
--- a/pfSense-pkg-API/files/etc/inc/api/models/APIInterfaceCreate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIInterfaceCreate.inc
@@ -667,12 +667,12 @@ class APIInterfaceCreate extends APIModel {
             $track_prefix = $this->initial_data["track6-prefix-id-hex"];
             // Check that our gateway is a valid IPv4 address
             if (is_numeric($track_prefix) and ctype_xdigit(strval($track_prefix))) {
-                $this->validated_data["track6-prefix-id--hex"] = intval($track_prefix);
+                $this->validated_data["track6-prefix-id"] = intval($track_prefix);
             } else {
                 $this->errors[] = APIResponse\get(3040);
             }
         } else {
-            $this->validated_data["track6-prefix-id--hex"] = 0;
+            $this->validated_data["track6-prefix-id"] = 0;
         }
     }
 

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIInterfaceUpdate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIInterfaceUpdate.inc
@@ -775,12 +775,12 @@ class APIInterfaceUpdate extends APIModel {
             $track_prefix = $this->initial_data["track6-prefix-id-hex"];
             // Check that our gateway is a valid IPv4 address
             if (is_numeric($track_prefix) and ctype_xdigit(strval($track_prefix))) {
-                $this->validated_data["track6-prefix-id--hex"] = intval($track_prefix);
+                $this->validated_data["track6-prefix-id"] = intval($track_prefix);
             } else {
                 $this->errors[] = APIResponse\get(3040);
             }
-        } elseif (!isset($this->validated_data["track6-prefix-id--hex"])) {
-            $this->validated_data["track6-prefix-id--hex"] = 0;
+        } elseif (!isset($this->validated_data["track6-prefix-id"])) {
+            $this->validated_data["track6-prefix-id"] = 0;
         }
     }
 


### PR DESCRIPTION
When creating or updating an interface with track6 as the type6 setting, 
the API currently always writes 0 as the prefix id, regardless of the actually specified id.
This is cause by an incorrect identifier in the validated_data array.
Here `track6-prefix-id--hex` is set, but the identifier should actually be `track6-prefix-id`.

This PR fixes that, and has been tested on pfsense 2.5.