### PR TITLE
Allow flushing of all Unbound host overrides

### DIFF
--- a/pfSense-pkg-API/files/etc/inc/api/endpoints/APIServicesUnboundHostOverrideFlush.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/endpoints/APIServicesUnboundHostOverrideFlush.inc
@@ -1,0 +1,26 @@
+<?php
+//   Copyright 2022 Jared Hendrickson
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+require_once("api/framework/APIEndpoint.inc");
+
+class APIServicesUnboundHostOverrideFlush extends APIEndpoint {
+    public function __construct() {
+        $this->url = "/api/v1/services/unbound/host_override/flush";
+    }
+
+    protected function delete() {
+        return (new APIServicesUnboundHostOverrideFlushDelete())->call();
+    }
+}

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIServicesUnboundHostOverrideFlushDelete.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIServicesUnboundHostOverrideFlushDelete.inc
@@ -1,0 +1,38 @@
+<?php
+//   Copyright 2022 Jared Hendrickson
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+require_once("api/framework/APIModel.inc");
+require_once("api/framework/APIResponse.inc");
+
+class APIServicesUnboundHostOverrideFlushDelete extends APIModel {
+    # Create our method constructor
+    public function __construct() {
+        parent::__construct();
+        $this->privileges = ["page-all", "page-services-dnsresolver-edithost"];
+        $this->change_note = "Flushed DNS Resolver host overrides via API";
+    }
+
+    public function action() {
+        # Capture all host overrides, remove them from the config and save the changes.
+        $this->validated_data = $this->config["unbound"]["hosts"];
+        unset($this->config["unbound"]["hosts"]);
+        $this->write_config();
+
+        # Mark the Unbound subsystem as changed, but do not allow clients to immediately apply the change.
+        mark_subsystem_dirty("unbound");
+
+        return APIResponse\get(0, $this->validated_data);
+    }
+}

--- a/pfSense-pkg-API/files/usr/local/www/api/documentation/openapi.yml
+++ b/pfSense-pkg-API/files/usr/local/www/api/documentation/openapi.yml
@@ -7282,6 +7282,22 @@ paths:
       summary: Create DNS Resolver (Unbound) host override alias
       tags:
         - Services > Unbound > Host Override > Alias
+  /api/v1/services/unbound/host_override/flush:
+    delete:
+      description: 'Deletes all existing DNS Resolver (Unbound) host overrides. This is useful for scripts
+          that need to setup host overrides from scratch.<br><br>_Note: this endpoint
+          will not reload the DNS Resolver (Unbound) service automatically, you must make another API
+          call to the /api/v1/services/unbound/apply endpoint to do so._.<br><br>
+
+          _Requires at least one of the following privileges:_ [`page-all`, `page-firewall-rules-edit`]'
+      responses:
+        200:
+          $ref: '#/components/responses/Success'
+        401:
+          $ref: '#/components/responses/AuthenticationFailed'
+      summary: Delete all DNS Resolver (Unbound) host overrides
+      tags:
+        - Services > Unbound > Host Override > Flush
   /api/v1/services/unbound/restart:
     post:
       description: 'Restart the DNS Resolver (Unbound) service.<br><br>
@@ -9395,6 +9411,7 @@ tags:
   - name: Services > Unbound > Access List > Row
   - name: Services > Unbound > Host Override
   - name: Services > Unbound > Host Override > Alias
+  - name: Services > Unbound > Host Override > Flush
   - name: Services > DNSMASQ
   - name: Services > DNSMASQ > Host Override
   - name: Services > DNSMASQ > Host Override > Alias

--- a/tests/test_api_v1_services_unbound_host_override_flush.py
+++ b/tests/test_api_v1_services_unbound_host_override_flush.py
@@ -1,0 +1,24 @@
+# Copyright 2022 Jared Hendrickson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import e2e_test_framework
+
+class APIE2ETestServicesUnboundHostOverrideFlush(e2e_test_framework.APIE2ETest):
+    uri = "/api/v1/services/unbound/host_override/flush"
+
+    delete_tests = [
+        {"name": "Flush all Unbound host overrides", "payload": {}},
+    ]
+
+APIE2ETestServicesUnboundHostOverrideFlush()


### PR DESCRIPTION
- Adds /api/v1/services/unbound/host_override/flush endpoint to allow deletion of all existing host overrides