### PR TITLE
v1.4.2 Fixes & Features

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -366,6 +366,13 @@ Often times you will need to create functions to condense redundant tasks. You c
 
 `$some_variable = APITools\your_custom_tool_function();`
 
+As a general rule, functions should be kept within the API model they relate closest to. For example, a function that
+checks for the existence of an alias by name should be kept in the APIFirewallAlias* models, even if multiple models
+will use the function. Tool functions should only be used in one of the following situations:
+- Multiple models, endpoints or tools use the function and the function does not directly relate to any of the existing
+API models, or it directly relates to multiple models.
+- Use of the function causes an `include` or `require` loop.
+
 
 ## Writing API E2E Tests ##
 E2E tests are written using Python3. pfSense API includes a an e2e_test_framework module in the `tests` directory to make

--- a/pfSense-pkg-API/files/etc/inc/api/endpoints/APIFirewallRuleFlush.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/endpoints/APIFirewallRuleFlush.inc
@@ -20,6 +20,10 @@ class APIFirewallRuleFlush extends APIEndpoint {
         $this->url = "/api/v1/firewall/rule/flush";
     }
 
+    protected function put() {
+        return (new APIFirewallRuleFlushUpdate())->call();
+    }
+
     protected function delete() {
         return (new APIFirewallRuleFlushDelete())->call();
     }

--- a/pfSense-pkg-API/files/etc/inc/api/endpoints/APIRoutingGatewayDefault.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/endpoints/APIRoutingGatewayDefault.inc
@@ -1,0 +1,26 @@
+<?php
+//   Copyright 2022 Jared Hendrickson
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+require_once("api/framework/APIEndpoint.inc");
+
+class APIRoutingGatewayDefault extends APIEndpoint {
+    public function __construct() {
+        $this->url = "/api/v1/routing/gateway/default";
+    }
+
+    protected function put() {
+        return (new APIRoutingGatewayDefaultUpdate())->call();
+    }
+}

--- a/pfSense-pkg-API/files/etc/inc/api/endpoints/APIServicesUnboundHostOverrideFlush.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/endpoints/APIServicesUnboundHostOverrideFlush.inc
@@ -20,6 +20,10 @@ class APIServicesUnboundHostOverrideFlush extends APIEndpoint {
         $this->url = "/api/v1/services/unbound/host_override/flush";
     }
 
+    protected function put() {
+        return (new APIServicesUnboundHostOverrideFlushUpdate())->call();
+    }
+
     protected function delete() {
         return (new APIServicesUnboundHostOverrideFlushDelete())->call();
     }

--- a/pfSense-pkg-API/files/etc/inc/api/framework/APIResponse.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/framework/APIResponse.inc
@@ -1187,6 +1187,12 @@ function get($id, $data=[], $all=false) {
             "return" => $id,
             "message" => "DHCPd option with type ip-address must be valid IPv4 address or hostname"
         ],
+        2098 => [
+            "status" => "bad request",
+            "code" => 400,
+            "return" => $id,
+            "message" => "Host overrides must be contained within an array"
+        ],
         2999 => [
             "status" => "bad request",
             "code" => 400,

--- a/pfSense-pkg-API/files/etc/inc/api/framework/APIResponse.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/framework/APIResponse.inc
@@ -3087,7 +3087,18 @@ function get($id, $data=[], $all=false) {
             "return" => $id,
             "message" => "Unknown API floating rule direction specified"
         ],
-
+        4240 => [
+            "status" => "bad request",
+            "code" => 400,
+            "return" => $id,
+            "message" => "Rules must be contained within an array"
+        ],
+        4241 => [
+            "status" => "bad request",
+            "code" => 400,
+            "return" => $id,
+            "message" => "Rules must contain at least one item"
+        ],
 
         //5000-5999 reserved for /users API calls
         5000 => [

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallRuleCreate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallRuleCreate.inc
@@ -368,7 +368,7 @@ class APIFirewallRuleCreate extends APIModel {
         }
     }
 
-    public function validate_payload() {
+    public function validate_payload($delay_tracker=true) {
         $this->__validate_type();
         $this->__validate_interface();
         $this->__validate_ipprotocol();
@@ -393,7 +393,7 @@ class APIFirewallRuleCreate extends APIModel {
 
         # Delay generating the tracker. Reduces the likelihood of two rules getting the same tracker in looped calls.
         # todo: this is a quick fix and still does not guarantee uniqueness, a better solution is needed
-        if (!$this->errors) {
+        if (!$this->errors and $delay_tracker) {
             sleep(1);
         }
 

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallRuleFlushUpdate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallRuleFlushUpdate.inc
@@ -1,0 +1,88 @@
+<?php
+//   Copyright 2022 Jared Hendrickson
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+require_once("api/framework/APIModel.inc");
+require_once("api/framework/APIResponse.inc");
+
+class APIFirewallRuleFlushUpdate extends APIModel {
+    # Create our method constructor
+    public function __construct() {
+        parent::__construct();
+        $this->privileges = ["page-all", "page-firewall-rules-edit"];
+        $this->change_note = "Flushed and replaced firewall rules via API";
+    }
+
+    public function action() {
+        $this->__randomize_tracker();
+        $this->config["filter"]["rule"] = $this->validated_data;
+        APITools\sort_firewall_rules();
+        $this->write_config();
+        mark_subsystem_dirty('filter');
+
+        # Only reload the firewall filter if it was requested by the client
+        if ($this->initial_data["apply"] === true) {
+            APIFirewallApplyCreate::apply();
+        }
+
+        return APIResponse\get(0, $this->config["filter"]["rule"]);
+    }
+
+    public function validate_payload() {
+        # Require data to be passed in as an array
+        if (is_array($this->initial_data["rules"])) {
+            # Require at least one rule to be present
+            if (count($this->initial_data["rules"]) >= 1) {
+                # Loop through and validate each rule entry requested
+                foreach ($this->initial_data["rules"] as $initial_rule) {
+                    # Check if this entry is valid for creation using the APIFirewallRuleCreate class
+                    $ent = new APIFirewallRuleCreate();
+                    $ent->client = $this->client;
+                    $ent->initial_data = $initial_rule;
+                    $ent->validate_payload(false);
+
+                    # Check if an occurred while validating this entry
+                    if ($ent->errors) {
+                        # Grab the error's return code and raise error including the bad entry in the data field
+                        $rc = $ent->errors[0]["return"];
+                        $this->errors[] = APIResponse\get($rc, $initial_rule);
+                        break;
+                    } # Otherwise, if the entry was valid, add it to our validated host overrides
+                    else {
+                        $this->validated_data[] = $ent->validated_data;
+                    }
+                }
+            }
+            # Raise an error if an empty array was passed in
+            else {
+                $this->errors[] = APIResponse\get(4241);
+            }
+        }
+        # Raise an error if rules were not passed in as an array
+        else {
+            $this->errors[] = APIResponse\get(4240);
+        }
+    }
+
+    private function __randomize_tracker() {
+        # Capture the current microsecond value as a starting point
+        $tracker = (int)microtime(true);
+
+        # Loop through each tracker ID and assign it a unique tracker
+        foreach($this->validated_data as $id=>$rule) {
+            $this->validated_data[$id]["tracker"] = $tracker;
+            $tracker--;
+        }
+    }
+}

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIRoutingGatewayDefaultUpdate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIRoutingGatewayDefaultUpdate.inc
@@ -1,0 +1,108 @@
+<?php
+//   Copyright 2022 Jared Hendrickson
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+require_once("api/framework/APIModel.inc");
+require_once("api/framework/APIResponse.inc");
+
+
+class APIRoutingGatewayDefaultUpdate extends APIModel {
+    # Create our method constructor
+    public function __construct() {
+        parent::__construct();
+        $this->privileges = ["page-all", "page-system-gateways"];
+        $this->change_note = "Set default gateway via API";
+    }
+
+    public function action() {
+        # Set the default gateways based on the validated input
+        $this->config["gateways"]["defaultgw4"] = $this->validated_data["defaultgw4"];
+        $this->config["gateways"]["defaultgw6"] = $this->validated_data["defaultgw6"];
+
+        # Write these changes to config and apply if the client requested
+        $this->write_config();
+        $this->apply();
+        return APIResponse\get(0, $this->validated_data);
+    }
+
+    private function __validate_defaultgw4() {
+        # Optionally allow clients to update the 'defaultgw4' value
+        if (isset($this->initial_data["defaultgw4"])) {
+            # Ensure this is a valid IPv4 gateway
+            if (APITools\is_gateway($this->initial_data["defaultgw4"], true) === "inet") {
+                $this->validated_data["defaultgw4"] = $this->initial_data["defaultgw4"];
+            }
+            # Allow client to set automatic gateway selection
+            elseif (in_array($this->initial_data["defaultgw4"], ["", "automatic"])) {
+                $this->validated_data["defaultgw4"] = "";
+            }
+            # Allow client to set no gateway
+            elseif (in_array($this->initial_data["defaultgw4"], ["-", "none"])) {
+                $this->validated_data["defaultgw4"] = "-";
+            }
+            else {
+                $this->errors[] = APIResponse\get(6028);
+            }
+        }
+    }
+
+    private function __validate_defaultgw6() {
+        # Optionally allow clients to update the 'defaultgw6' value
+        if (isset($this->initial_data["defaultgw6"])) {
+            # Ensure this is a valid IPv6 gateway
+            if (APITools\is_gateway($this->initial_data["defaultgw6"], true) === "inet6") {
+                $this->validated_data["defaultgw6"] = $this->initial_data["defaultgw6"];
+            }
+            # Allow client to set automatic gateway selection
+            elseif (in_array($this->initial_data["defaultgw6"], ["", "automatic"])) {
+                $this->validated_data["defaultgw6"] = "";
+            }
+            # Allow client to set no gateway
+            elseif (in_array($this->initial_data["defaultgw6"], ["-", "none"])) {
+                $this->validated_data["defaultgw6"] = "-";
+            }
+            else {
+                $this->errors[] = APIResponse\get(6028);
+            }
+        }
+    }
+
+    public function validate_payload() {
+        # Fetch existing default gateway values
+        $this->validated_data = [
+            "defaultgw4"=>$this->config["gateways"]["defaultgw4"],
+            "defaultgw6"=>$this->config["gateways"]["defaultgw6"],
+        ];
+
+        # Validate client input
+        $this->__validate_defaultgw4();
+        $this->__validate_defaultgw6();
+    }
+
+    public function apply() {
+        # Mark the routing subsystem as changed, clear if applied
+        mark_subsystem_dirty("staticroutes");
+
+        # Optionally allow clients to apply this route immediately if they passed in a true apply value
+        # Note: this is a one-off case where this was better to default to true instead of false.
+        if ($this->initial_data["apply"] !== false) {
+            system_routing_configure();
+            system_resolvconf_generate();
+            filter_configure();
+            setup_gateways_monitor();
+            send_event("service reload dyndnsall");
+            clear_subsystem_dirty("staticroutes");
+        }
+    }
+}

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIServicesUnboundHostOverrideFlushUpdate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIServicesUnboundHostOverrideFlushUpdate.inc
@@ -1,0 +1,70 @@
+<?php
+//   Copyright 2022 Jared Hendrickson
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+require_once("api/framework/APIModel.inc");
+require_once("api/framework/APIResponse.inc");
+
+class APIServicesUnboundHostOverrideFlushUpdate extends APIModel {
+    # Create our method constructor
+    public function __construct() {
+        parent::__construct();
+        $this->privileges = ["page-all", "page-services-dnsresolver-edithost"];
+        $this->change_note = "Flushed and replaced DNS Resolver host overrides via API";
+    }
+
+    public function action() {
+        # Replace any existing host overrides with the host overrides validated in this request
+        $this->config["unbound"]["hosts"] = $this->validated_data;
+        $this->write_config();
+
+        # Mark the Unbound subsystem as changed.
+        mark_subsystem_dirty("unbound");
+
+        # Apply the changes if requested
+        if ($this->initial_data["apply"] === true) {
+            (new APIServicesUnboundApplyCreate)->action();
+        }
+
+        return APIResponse\get(0, $this->validated_data);
+    }
+
+    public function validate_payload() {
+        # Require data to be passed in as an array
+        if (is_array($this->initial_data["host_overrides"])) {
+            # Loop through each host override entry requested
+            foreach ($this->initial_data["host_overrides"] as $initial_host_override) {
+                # Check if this entry is valid for creation using the APIServicesUnboundHostOverrideCreate class
+                $ent = new APIServicesUnboundHostOverrideCreate();
+                $ent->initial_data = $initial_host_override;
+                $ent->validate_payload();
+
+                # Check if an occurred while validating this entry
+                if ($ent->errors) {
+                    # Grab the error's return code and raise error including the bad entry in the data field
+                    $rc = $ent->errors[0]["return"];
+                    $this->errors[] = APIResponse\get($rc, $initial_host_override);
+                    break;
+                } # Otherwise, if the entry was valid, add it to our validated host overrides
+                else {
+                    $this->validated_data[] = $ent->validated_data;
+                }
+            }
+        }
+        # Raise an error if host overrides were not passed in as an array
+        else {
+            $this->errors[] = APIResponse\get(2098);
+        }
+    }
+}

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIServicesUnboundHostOverrideFlushUpdate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIServicesUnboundHostOverrideFlushUpdate.inc
@@ -16,6 +16,10 @@
 require_once("api/framework/APIModel.inc");
 require_once("api/framework/APIResponse.inc");
 
+function unbound_override_flush_host_cmp($a, $b) {
+    return strcasecmp($a['host'], $b['host']);
+}
+
 class APIServicesUnboundHostOverrideFlushUpdate extends APIModel {
     # Create our method constructor
     public function __construct() {
@@ -27,6 +31,7 @@ class APIServicesUnboundHostOverrideFlushUpdate extends APIModel {
     public function action() {
         # Replace any existing host overrides with the host overrides validated in this request
         $this->config["unbound"]["hosts"] = $this->validated_data;
+        usort($this->config["unbound"]["hosts"], "unbound_override_flush_host_cmp");
         $this->write_config();
 
         # Mark the Unbound subsystem as changed.
@@ -37,7 +42,7 @@ class APIServicesUnboundHostOverrideFlushUpdate extends APIModel {
             (new APIServicesUnboundApplyCreate)->action();
         }
 
-        return APIResponse\get(0, $this->validated_data);
+        return APIResponse\get(0, $this->config["unbound"]["hosts"]);
     }
 
     public function validate_payload() {

--- a/pfSense-pkg-API/files/usr/local/www/api/documentation/openapi.yml
+++ b/pfSense-pkg-API/files/usr/local/www/api/documentation/openapi.yml
@@ -5652,6 +5652,43 @@ paths:
       summary: Update gateway
       tags:
         - Routing > Gateway
+  /api/v1/routing/gateway/default:
+    put:
+      description: 'Update the default gateways for IPv4 and/or IPv6. _Note: changing the default gateway can
+      prevent you from connecting to the system afterward. Proceed with caution._<br><br>
+
+        _Requires at least one of the following privileges:_ [`page-all`, `page-system-gateways`]'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                defaultgw4:
+                  description: >-
+                    Set the IPv4 default gateway. This must be an existing IPv4 gateway name, `automatic` for automatic
+                    gateway selection, or `none` for no default gateway selection for IPv4.
+                  type: string
+                defaultgw6:
+                  description: >-
+                    Set the IPv6 default gateway. This must be an existing IPv6 gateway name, `automatic` for automatic
+                    gateway selection, or `none` for no default gateway selection for IPv6.
+                  type: string
+                apply:
+                  default: true
+                  description: Specify whether or not you would like this change
+                    to be applied immediately, or simply written to the configuration
+                    to be applied later. If set to `false` you must apply the changes
+                    afterwards using the `/api/v1/routing/apply` endpoint.
+                  type: boolean
+              type: object
+      responses:
+        200:
+          $ref: '#/components/responses/Success'
+        401:
+          $ref: '#/components/responses/AuthenticationFailed'
+      summary: Update default gateways
+      tags:
+        - Routing > Gateway > Default
   /api/v1/routing/gateway/detail:
     get:
       description: 'Read verbose routing gateway details about both dynamic/system
@@ -9512,6 +9549,7 @@ tags:
   - name: System > Reboot
   - name: System > Halt
   - name: Routing > Gateway
+  - name: Routing > Gateway > Default
   - name: Routing > Gateway > Detail
   - name: Routing > Static Route
   - name: Routing > Apply

--- a/pfSense-pkg-API/files/usr/local/www/api/documentation/openapi.yml
+++ b/pfSense-pkg-API/files/usr/local/www/api/documentation/openapi.yml
@@ -7300,7 +7300,7 @@ paths:
   /api/v1/services/unbound/host_override/flush:
     put:
       description: 'Replace all existing DNS Resolver (Unbound) host overrides with a specified set of host overrides.
-        This allows you to create multiple host overrides at once. If validation error is encountered when validating
+        This allows you to create multiple host overrides at once. If a validation error is encountered when validating
         the host overrides, the specific entry that triggered the error will be included in the `data` field of the 
         response.<br><br>
 

--- a/pfSense-pkg-API/files/usr/local/www/api/documentation/openapi.yml
+++ b/pfSense-pkg-API/files/usr/local/www/api/documentation/openapi.yml
@@ -2401,8 +2401,60 @@ paths:
       tags:
         - Firewall > Rule
   /api/v1/firewall/rule/flush:
+    put:
+      description: 'Replace all existing firewall rules with a specified set of rules. This allows you to
+            create rules at once. If a validation error is encountered when validating the rules, the specific 
+            rule entry that triggered the error will be included in the `data` field of the response. <br><br>_Note:
+            the pfSense webConfigurator and /api/v1/firewall/rule API endpoint will create the `tracker` ID for
+            rules based on the time they were created, and essentially limits creations to 1 rule per second to
+            avoid conflicts. To get around this restriction, this endpoint will use randomized `tracker` IDs 
+            instead. The potential effects of this are somewhat unknown, proceed with caution._<br><br>
+
+            _Requires at least one of the following privileges:_ [`page-all`, `page-firewall-rules-edit`]'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                rules:
+                  type: array
+                  minItems: 1
+                  items:
+                    type: object
+                  description: Firewall rule objects to replace existing firewall rules with. Each object within this 
+                    array can use any properties available to the /api/v1/firewall/rule endpoint.
+                  example:
+                    - type: pass
+                      interface: wan
+                      ipprotocol: inet46
+                      protocol: any
+                      src: any
+                      dst: any
+                    - type: pass
+                      interface: lan
+                      ipprotocol: inet
+                      protocol: any
+                      src: lan
+                      dst: any
+                apply:
+                  default: false
+                  description: Specify whether or not you would like these firewall rules
+                    to be applied immediately, or simply written to the configuration
+                    to be applied later using the /api/v1/firewall/apply endpoint.
+                  type: boolean
+              required:
+                - rules
+              type: object
+      responses:
+        200:
+          $ref: '#/components/responses/Success'
+        401:
+          $ref: '#/components/responses/AuthenticationFailed'
+      summary: Replace all firewall rules
+      tags:
+        - Firewall > Rule > Flush
     delete:
-      description: 'Deletes all existing firewall rules. This is useful for scripts
+      description: 'Delete all existing firewall rules. This is useful for scripts
         that need to setup the firewall rules from scratch.<br><br>_Note: this endpoint
         will not reload the firewall filter automatically, you must make another API
         call to the /api/v1/firewall/apply endpoint to do so. Ensure firewall rules
@@ -7322,7 +7374,7 @@ paths:
                     type: object
                   description: Host override objects to replace existing host overrides with. Specifying an
                     empty array will remove all existing host overrides. Each object within this array can use any
-                    properties available on the /api/v1/services/unbound/host_override endpoint.
+                    properties available to the /api/v1/services/unbound/host_override endpoint.
                   example:
                     - host: example1
                       domain: example.com
@@ -7344,10 +7396,7 @@ paths:
                   default: false
                   description: Specify whether or not you would like these host overrides
                     to be applied immediately, or simply written to the configuration
-                    to be applied later. Typically, if you are creating multiple host
-                    override aliases at once it Is best to set this to false and apply
-                    the changes afterwards using the `/api/v1/services/unbound/apply`
-                    endpoint.
+                    to be applied later using the /api/v1/services/unbound/apply endpoint.
                   type: boolean
               required:
                 - host_overrides

--- a/pfSense-pkg-API/files/usr/local/www/api/documentation/openapi.yml
+++ b/pfSense-pkg-API/files/usr/local/www/api/documentation/openapi.yml
@@ -7298,6 +7298,62 @@ paths:
       tags:
         - Services > Unbound > Host Override > Alias
   /api/v1/services/unbound/host_override/flush:
+    put:
+      description: 'Replace all existing DNS Resolver (Unbound) host overrides with a specified set of host overrides.
+        This allows you to create multiple host overrides at once. If validation error is encountered when validating
+        the host overrides, the specific entry that triggered the error will be included in the `data` field of the 
+        response.<br><br>
+
+        _Requires at least one of the following privileges:_ [`page-all`, `page-services-dnsresolver-edithost`]'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                host_overrides:
+                  type: array
+                  items:
+                    type: object
+                  description: Host override objects to replace existing host overrides with. Specifying an
+                    empty array will remove all existing host overrides. Each object within this array can use any
+                    properties available on the /api/v1/services/unbound/host_override endpoint.
+                  example:
+                    - host: example1
+                      domain: example.com
+                      ip: [127.0.0.1]
+                      descr: "Example entry #1"
+                      aliases:
+                        - host: example1-alias
+                          domain: example.com
+                          description: "Example entry #1 alias"
+                    - host: example2
+                      domain: example.com
+                      ip: [127.0.0.2]
+                      descr: "Example entry #2"
+                      aliases:
+                        - host: example2-alias
+                          domain: example.com
+                          description: "Example entry #2 alias"
+                apply:
+                  default: false
+                  description: Specify whether or not you would like these host overrides
+                    to be applied immediately, or simply written to the configuration
+                    to be applied later. Typically, if you are creating multiple host
+                    override aliases at once it Is best to set this to false and apply
+                    the changes afterwards using the `/api/v1/services/unbound/apply`
+                    endpoint.
+                  type: boolean
+              required:
+                - host_overrides
+              type: object
+      responses:
+        200:
+          $ref: '#/components/responses/Success'
+        401:
+          $ref: '#/components/responses/AuthenticationFailed'
+      summary: Replace all DNS Resolver (Unbound) host overrides
+      tags:
+        - Services > Unbound > Host Override > Flush
     delete:
       description: 'Deletes all existing DNS Resolver (Unbound) host overrides. This is useful for scripts
           that need to setup host overrides from scratch.<br><br>_Note: this endpoint

--- a/pfSense-pkg-API/files/usr/local/www/api/documentation/openapi.yml
+++ b/pfSense-pkg-API/files/usr/local/www/api/documentation/openapi.yml
@@ -4253,7 +4253,8 @@ paths:
                   type: boolean
                 gateway:
                   description: Name of upstream IPv4 gateway for this interface. This
-                    is only necessary on WAN/UPLINK interfaces.
+                    is only necessary on WAN/UPLINK interfaces. This parameter is only
+                    available when `type` is set to `staticv4`.
                   type: string
                 gateway-6rd:
                   description: Set the 6RD interface IPv4 gateway address. This parameter
@@ -4514,7 +4515,8 @@ paths:
                   type: boolean
                 gateway:
                   description: Name of upstream IPv4 gateway for this interface. This
-                    is only necessary on WAN/UPLINK interfaces.
+                    is only necessary on WAN/UPLINK interfaces. This parameter is only
+                    available when `type` is set to `staticv4`.
                   type: string
                 gateway-6rd:
                   description: Set the 6RD interface IPv4 gateway address. This parameter
@@ -4602,13 +4604,17 @@ paths:
                     `track6`
                   type: integer
                 type:
-                  description: IPv4 configuration type.
+                  description: IPv4 configuration type. This parameter may be required in order to update
+                    specific parameters. For example, this parameter must be set to `staticv4` in order to 
+                    update the `gateway` parameter.
                   enum:
                     - staticv4
                     - dhcp
                   type: string
                 type6:
-                  description: IPv6 configuration type.
+                  description: IPv6 configuration type. This parameter may be required in order to update
+                    specific parameters. For example, this parameter must be set to `staticv6` in order to
+                    update the `gatewayv6` parameter.
                   enum:
                     - staticv6
                     - dhcp6

--- a/tests/test_api_v1_firewall_rule_flush.py
+++ b/tests/test_api_v1_firewall_rule_flush.py
@@ -16,7 +16,45 @@ import e2e_test_framework
 
 class APIE2ETestFirewallRuleFlush(e2e_test_framework.APIE2ETest):
     uri = "/api/v1/firewall/rule/flush"
-
+    put_tests = [
+        {
+            "name": "Check rules array type constraint",
+            "status": 400,
+            "return": 4240
+        },
+        {
+            "name": "Check rules array minimum items constraint",
+            "status": 400,
+            "return": 4241,
+            "payload": {
+                "rules": []
+            }
+        },
+        {
+            "name": "Flush and replace all rules",
+            "payload": {
+                "apply": "true",
+                "rules": [
+                    {
+                        "type": "pass",
+                        "interface": "wan",
+                        "ipprotocol": "inet",
+                        "protocol": "any",
+                        "src": "any",
+                        "dst": "any"
+                    },
+                    {
+                        "type": "pass",
+                        "interface": "wan",
+                        "ipprotocol": "inet",
+                        "protocol": "any",
+                        "src": "lan",
+                        "dst": "any"
+                    }
+                ]
+            }
+        }
+    ]
     delete_tests = [
         {"name": "Flush all firewall rules", "payload": {}},
         {

--- a/tests/test_api_v1_routing_gateway_default.py
+++ b/tests/test_api_v1_routing_gateway_default.py
@@ -1,0 +1,39 @@
+# Copyright 2022 Jared Hendrickson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import e2e_test_framework
+
+class APIE2ETestRoutingGatewayDefault(e2e_test_framework.APIE2ETest):
+    uri = "/api/v1/routing/gateway/default"
+    put_tests = [
+        {
+            "name": "Check IPv4 gateway exists constraint",
+            "status": 400,
+            "return": 6028,
+            "payload": {"defaultgw4": "INVALID"}
+        },
+        {
+            "name": "Check IPv6 gateway exists constraint",
+            "status": 400,
+            "return": 6028,
+            "payload": {"defaultgw6": "INVALID"}
+        },
+        {
+            "name": "Check updating default gateways",
+            "timeout": 10,
+            "payload": {"defaultgw4": "automatic", "defaultgw6": "automatic"}
+        }
+    ]
+
+APIE2ETestRoutingGatewayDefault()

--- a/tests/test_api_v1_services_unbound_host_override_flush.py
+++ b/tests/test_api_v1_services_unbound_host_override_flush.py
@@ -16,9 +16,41 @@ import e2e_test_framework
 
 class APIE2ETestServicesUnboundHostOverrideFlush(e2e_test_framework.APIE2ETest):
     uri = "/api/v1/services/unbound/host_override/flush"
-
+    put_tests = [
+        {
+            "name": "Check host_overrides field array requirement",
+            "return": 2098,
+            "status": 400
+        },
+        {
+            "name": "Check ability to replace all existing host overrides",
+            "payload": {
+                "host_overrides": [
+                    {
+                        "host": "test1",
+                        "domain": "example.com",
+                        "ip": ["127.0.0.1"],
+                        "descr": "Entry #1",
+                        "aliases": [
+                            {"host": "test1-alias", "domain": "example.com"}
+                        ]
+                    },
+                    {
+                        "host": "test2",
+                        "domain": "example.com",
+                        "ip": ["127.0.0.1"],
+                        "descr": "Entry #2",
+                        "aliases": [
+                            {"host": "test2-alias", "domain": "example.com"}
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
     delete_tests = [
         {"name": "Flush all Unbound host overrides", "payload": {}},
     ]
+
 
 APIE2ETestServicesUnboundHostOverrideFlush()

--- a/tools/README.md
+++ b/tools/README.md
@@ -9,8 +9,15 @@ compile the package automatically if you run it on a FreeBSD system. Files are r
 found in the `templates` subdirectory
 
 ### Usage
-`python3 tools/make_package.py`
+To build in-place on FreeBSD:
+`python3 tools/make_package.py --branch <BRANCH NAME TO TARGET> --tag <VERSION TO ASSIGN PACKAGE> --freebsd <FREEBSD VERSION>`
 
+To build on a remote FreeBSD host using SSH/SCP:
+`python3 tools/make_package --remote --host <IP or HOSTNAME OF FREEBSD> --branch <BRANCH NAME TO TARGET> --tag <VERSION TO ASSIGN PACKAGE> --freebsd <FREEBSD VERSION>`
+
+For example:
+`python3 tools/make_package --remote --host 192.168.1.25 --branch master --tag 0.0.4 --freebsd 12
+`
 ### Dependencies
 - `Jinja2` package must be installed before running (`python3 -m pip install jinja2`)
 
@@ -22,6 +29,8 @@ Command will output the FreeBSD make command output. Outputs the following files
 - `pfsense-api/pfSense-pkg-API/pfSense-pkg-API-<VERSION>.txz` : The FreeBSD package distribution file. On FreeBSD 11, 
 this should be located in the `pfsense-api/pfSense-pkg-API` directory after completion. On FreeBSD 12 it should be 
 located in the `pfsense-api/pfSense-pkg-API/work/pkg` directory.
+
+If you have run the script using the `--remote` flag, the built package will be copied to your local system using SCP.
 
 ### Notes
 - This script heavily depends on it's relative filepaths. You may execute the script from any directory, but do not move


### PR DESCRIPTION
- Adds support for PUT requests to /api/v1/services/unbound/host_override/flush endpoint to replace all host overrides with a list of specified host overrides.
- Adds /api/v1/routing/gateway/default endpoint to update the default gateway. (#231)
- Documentation enhancements.