### PR TITLE
Fix typo for 'allowed_interfaces' on /api/v1/system/api documentation

### DIFF
--- a/pfSense-pkg-API/files/usr/local/www/api/documentation/openapi.yml
+++ b/pfSense-pkg-API/files/usr/local/www/api/documentation/openapi.yml
@@ -7714,7 +7714,7 @@ paths:
                     - jwt
                     - token
                   type: string
-                available_interfaces:
+                allowed_interfaces:
                   description: Interfaces that are allowed to answer API requests.
                     Each item in the array must be a valid real interface ID (e.g.
                     `em0`), pfSense interface ID, (e.g. `opt1`), or descriptive interface


### PR DESCRIPTION
- Fixes typo in /api/v1/system/api documentation that wrongfully states the 'allowed_interfaces' field as 'available_interfaces' (#246)
