### PR TITLE
Control test's order of precedence

### DIFF
--- a/tests/run_all_tests.py
+++ b/tests/run_all_tests.py
@@ -19,7 +19,7 @@ import sys
 
 # Variables
 tests_dir = pathlib.Path(__file__).parent.absolute()
-tests = [f for f in os.listdir(tests_dir) if f.startswith("test") and f.endswith(".py")]
+tests = sorted([f for f in os.listdir(tests_dir) if f.startswith("test") and f.endswith(".py")])
 success_count = 0
 exit_code = 0
 

--- a/tests/test_api_v1_user_group_member.py
+++ b/tests/test_api_v1_user_group_member.py
@@ -35,17 +35,27 @@ class APIE2ETestUserGroupMember(e2e_test_framework.APIE2ETest):
             }
         },
         {
+            "name": "Create group for use in tests",
+            "uri": "/api/v1/user/group",
+            "payload": {
+                "name": "TEST_GROUP",
+                "scope": "local",
+                "member": [],
+                "priv": ["page-all"]
+            }
+        },
+        {
             "name": "Add user to admins group",
             "payload": {
                 "username": "admin",
-                "group": ["admins"]
+                "group": ["TEST_GROUP"]
             }
         },
         {
             "name": "Check ability to add single group as string",
             "payload": {
                 "username": "admin",
-                "group": "admins"
+                "group": "TEST_GROUP"
             }
         }
     ]
@@ -84,14 +94,29 @@ class APIE2ETestUserGroupMember(e2e_test_framework.APIE2ETest):
             "name": "Remove user from admins group",
             "payload": {
                 "username": "admin",
-                "group": ["admins"]
+                "group": ["TEST_GROUP"]
+            }
+        },
+        {
+            "name": "Re-add user to test group",
+            "method": "POST",
+            "payload": {
+                "username": "admin",
+                "group": ["TEST_GROUP"]
             }
         },
         {
             "name": "Check ability to remove single group as string",
             "payload": {
                 "username": "admin",
-                "group": "admins"
+                "group": "TEST_GROUP"
+            }
+        },
+        {
+            "name": "Delete test group",
+            "uri": "/api/v1/user/group",
+            "payload": {
+                "id": "TEST_GROUP"
             }
         }
     ]


### PR DESCRIPTION
- Changes run_all_tests.py to execute each test in alphabetical order.
- Fixes issue test_api_v1_user_group_member.py that would revoke the `admin` user's admin privileges causing all subsequent tests to fail with a 403 forbidden response.