### PR TITLE
Advanced alias endpoint

### DIFF
--- a/pfSense-pkg-API/files/etc/inc/api/endpoints/APIFirewallAliasAdvanced.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/endpoints/APIFirewallAliasAdvanced.inc
@@ -1,0 +1,30 @@
+<?php
+//   Copyright 2022 Jared Hendrickson
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+require_once("api/framework/APIEndpoint.inc");
+
+class APIFirewallAliasAdvanced extends APIEndpoint {
+    public function __construct() {
+        $this->url = "/api/v1/firewall/alias/advanced";
+    }
+
+    protected function get() {
+        return (new APIFirewallAliasAdvancedRead())->call();
+    }
+
+    protected function put() {
+        return (new APIFirewallAliasAdvancedUpdate())->call();
+    }
+}

--- a/pfSense-pkg-API/files/etc/inc/api/framework/APIResponse.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/framework/APIResponse.inc
@@ -3501,6 +3501,12 @@ function get($id, $data=[], $all=false) {
             "return" => $id,
             "message" => "Rules must contain at least one item"
         ],
+        4242 => [
+            "status" => "bad request",
+            "code" => 400,
+            "return" => $id,
+            "message" => "Alias resolve interval must be numeric"
+        ],
 
         //5000-5999 reserved for /api/v1/user API calls
         5000 => [

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallAliasAdvancedRead.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallAliasAdvancedRead.inc
@@ -30,7 +30,7 @@ class APIFirewallAliasAdvancedRead extends APIModel {
     public function get_config() {
          return [
             "aliasesresolveinterval" => intval($this->config["system"]["aliasesresolveinterval"]),
-            "checkaliasesurlcert" => boolval($this->config["system"]["checkaliasesurlcert"])
+            "checkaliasesurlcert" => isset($this->config["system"]["checkaliasesurlcert"])
         ];
     }
 }

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallAliasAdvancedRead.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallAliasAdvancedRead.inc
@@ -1,0 +1,36 @@
+<?php
+//   Copyright 2022 Jared Hendrickson
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+require_once("api/framework/APIModel.inc");
+require_once("api/framework/APIResponse.inc");
+
+class APIFirewallAliasAdvancedRead extends APIModel {
+    # Create our method constructor
+    public function __construct() {
+        parent::__construct();
+        $this->privileges = ["page-all", "page-system-advanced-firewall"];
+    }
+
+    public function action() {
+        return APIResponse\get(0, $this->get_config());
+    }
+
+    public function get_config() {
+         return [
+            "aliasesresolveinterval" => intval($this->config["system"]["aliasesresolveinterval"]),
+            "checkaliasesurlcert" => boolval($this->config["system"]["checkaliasesurlcert"])
+        ];
+    }
+}

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallAliasAdvancedUpdate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallAliasAdvancedUpdate.inc
@@ -67,7 +67,7 @@ class APIFirewallAliasAdvancedUpdate extends APIModel {
             $this->validated_data["checkaliasesurlcert"] = true;
         }
         elseif ($this->initial_data["checkaliasesurlcert"] === false) {
-            unset($this->validated_data["checkaliasesurlcert"]);
+            unset($this->config["system"]["checkaliasesurlcert"]);
         }
     }
 

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallAliasAdvancedUpdate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallAliasAdvancedUpdate.inc
@@ -1,0 +1,84 @@
+<?php
+//   Copyright 2022 Jared Hendrickson
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+require_once("api/framework/APIModel.inc");
+require_once("api/framework/APIResponse.inc");
+
+class APIFirewallAliasAdvancedUpdate extends APIModel {
+    public $alias_interval_changed = false;
+
+    # Create our method constructor
+    public function __construct() {
+        parent::__construct();
+        $this->privileges = ["page-all", "page-system-advanced-firewall"];
+        $this->change_note = "Modified advanced firewall alias sttings via API";
+    }
+
+    public function action() {
+        # Write these changes to the config
+        $this->config["system"] = array_replace($this->config["system"], $this->validated_data);
+        $this->write_config();
+
+        # Restart filterdns when the alias interval changes
+        if ($this->alias_interval_changed) {
+            $this->restart_filterdns();
+        }
+
+        # Reload the filter to apply changes
+        filter_configure();
+
+        return APIResponse\get(0, (new APIFirewallAliasAdvancedRead())->get_config());
+    }
+
+    public function validate_payload() {
+        $this->__validate_aliasesresolveinterval();
+        $this->__validate_checkaliasesurlcert();
+    }
+
+    private function __validate_aliasesresolveinterval() {
+        # Check for the optional 'aliasesresolveinterval' field
+        if (isset($this->initial_data["aliasesresolveinterval"])) {
+            # Require value to be numeric integer
+            if (is_numeric($this->initial_data["aliasesresolveinterval"])) {
+                $this->validated_data["aliasesresolveinterval"] = intval($this->initial_data["aliasesresolveinterval"]);
+                $this->alias_interval_changed = true;
+            }
+            else {
+                $this->errors[] = APIResponse\get(4242);
+            }
+        }
+    }
+
+    private function __validate_checkaliasesurlcert() {
+        # Check for the optional 'checkaliasesurlcert' field
+        if ($this->initial_data["checkaliasesurlcert"] === true) {
+            $this->validated_data["checkaliasesurlcert"] = true;
+        }
+        elseif ($this->initial_data["checkaliasesurlcert"] === false) {
+            unset($this->validated_data["checkaliasesurlcert"]);
+        }
+    }
+
+    public static function restart_filterdns() {
+        global $g;
+
+        # If the filterdns process ID is present, kill it.
+        if (isvalidpid("{$g['varrun_path']}/filterdns.pid")) {
+            killbypid("{$g['varrun_path']}/filterdns.pid");
+        }
+    }
+
+
+}

--- a/pfSense-pkg-API/files/usr/local/www/api/documentation/openapi.yml
+++ b/pfSense-pkg-API/files/usr/local/www/api/documentation/openapi.yml
@@ -1126,6 +1126,47 @@ paths:
       summary: Add firewall alias entries
       tags:
         - Firewall > Alias > Entry
+  /api/v1/firewall/alias/advanced:
+    get:
+      operationId: APIFirewallAliasAdvancedRead
+      description: 'Read existing advanced alias settings.<br><br>
+
+
+        _Requires at least one of the following privileges:_ [`page-all`, `page-system-advanced-firewall`]'
+      responses:
+        "200":
+          $ref: '#/components/responses/Success'
+        "401":
+          $ref: '#/components/responses/AuthenticationFailed'
+      summary: Read advanced alias settings
+      tags:
+        - Firewall > Alias > Advanced
+    put:
+      operationId: APIFirewallAliasAdvancedUpdate
+      description: 'Update advanced firewall alias settings.<br><br>
+
+
+        _Requires at least one of the following privileges:_ [`page-all`, `page-system-advanced-firewall`]'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                aliasesresolveinterval:
+                  description: Interval (in seconds) at which hostnames in firewall aliases are updated.
+                  type: integer
+                checkaliasesurlcert:
+                  description: Enable or disable certificate verification when updating aliases via URL.
+                  type: boolean
+              type: object
+      responses:
+        "200":
+          $ref: '#/components/responses/Success'
+        "401":
+          $ref: '#/components/responses/AuthenticationFailed'
+      summary: Update advanced alias settings
+      tags:
+        - Firewall > Alias > Advanced
   /api/v1/firewall/apply:
     post:
       operationId: APIFirewallApplyCreate
@@ -12850,6 +12891,7 @@ tags:
   - name: Interface > Apply
   - name: Firewall > Alias
   - name: Firewall > Alias > Entry
+  - name: Firewall > Alias > Advanced
   - name: Firewall > Rule
   - name: Firewall > Rule > Flush
   - name: Firewall > Rule > Sort

--- a/tests/test_api_v1_firewall_alias_advanced.py
+++ b/tests/test_api_v1_firewall_alias_advanced.py
@@ -1,0 +1,44 @@
+# Copyright 2022 Jared Hendrickson
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Script used to test the /api/v1/firewall/nat/one_to_one endpoint."""
+import e2e_test_framework
+
+
+class APIE2ETestFirewallAliasAdvanced(e2e_test_framework.APIE2ETest):
+    """Class used to test the /api/v1/firewall/alias/advanced endpoint."""
+    uri = "/api/v1/firewall/alias/advanced"
+    get_tests = [
+        {"name": "Read all advanced alias settings"}
+    ]
+    put_tests = [
+        {
+            "name": "Update advanced alias settings",
+            "payload": {
+                "aliasesresolveinterval": 300,
+                "checkaliasesurlcert": True
+            },
+            "resp_time": 3    # Allow a few seconds for the firewall filter to reload
+        },
+        {
+            "name": "Ensure aliasesresolveinterval is numeric",
+            "status": 400,
+            "return": 4242,
+            "payload": {
+                "aliasesresolveinterval": "INVALID"
+            }
+        }
+    ]
+
+
+APIE2ETestFirewallAliasAdvanced()


### PR DESCRIPTION
- Adds APIFirewallAliasAdvancedRead and APIFirewallAliasAdvancedUpdate models to read and update advanced alias settings normally found in /system_advanced_firewall.php. 
- Adds APIFirewallAliasAdvanced endpoint at /api/v1/firewall/alias/advanced to call above models on GET and PUT respectively.
- Adds E2E tests for /api/v1/firewall/alias/advanced
- Adds API documentation on /api/v1/firewall/alias/advanced with available properties, methods, etc.