### PR TITLE
v1.5.1 Fixes

### DIFF
--- a/pfSense-pkg-API/files/etc/inc/api/framework/APIAuth.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/framework/APIAuth.inc
@@ -184,14 +184,8 @@ class APIAuth {
 
         # Log authentication attempts if enabled
         if (isset($this->api_config["enable_login_protection"])) {
-            # Log successful authentication
-            if ($authenticated) {
-                log_auth(
-                    gettext("Successful login for user '{$username}' from: {$ip_address} (Local Database)")
-                );
-            }
-            # Log failed authentication
-            else {
+            # Only log failed authentication
+            if (!$authenticated) {
                 log_auth(
                     gettext("webConfigurator authentication error for user '{$username}' from: {$ip_address}")
                 );

--- a/pfSense-pkg-API/files/etc/inc/api/framework/APIAuth.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/framework/APIAuth.inc
@@ -184,10 +184,17 @@ class APIAuth {
 
         # Log authentication attempts if enabled
         if (isset($this->api_config["enable_login_protection"])) {
-            # Only log failed authentication
+            # Log failed authentication
             if (!$authenticated) {
+                # This log entry is required for Login Protection to work, do not change the log text.
                 log_auth(
                     gettext("webConfigurator authentication error for user '{$username}' from: {$ip_address}")
+                );
+            }
+            # Log successful authentication if the API is configured to do so. Disabled by default to avoid log spam.
+            elseif (isset($this->api_config["log_successful_auth"])) {
+                log_auth(
+                    gettext("Successful login for user '{$username}' from: {$ip_address} (Local Database)")
                 );
             }
         }

--- a/pfSense-pkg-API/files/etc/inc/api/models/APISystemAPISyncUpdate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APISystemAPISyncUpdate.inc
@@ -18,6 +18,8 @@ require_once("api/framework/APIResponse.inc");
 
 
 class APISystemAPISyncUpdate extends APIModel {
+    public $pkg_index;
+    public $pkg_conf;
     # Create our method constructor
     public function __construct() {
         parent::__construct();
@@ -27,12 +29,14 @@ class APISystemAPISyncUpdate extends APIModel {
         $this->retain_read_mode = false;
         $this->ignore_enabled = true;
         $this->ignore_ifs = true;
+        $this->pkg_index = APITools\get_api_config()[0];
+        $this->pkg_conf = APITools\get_api_config()[1];
     }
 
     public function action() {
-        $pkg_index = APITools\get_api_config()[0];
-        $this->config["installedpackages"]["package"][$pkg_index]["conf"] = $this->validated_data;
+        $this->config["installedpackages"]["package"][$this->pkg_index]["conf"] = $this->validated_data;
         $this->write_config();
+        $this->backup();
         return APIResponse\get(0, $this->validated_data);
     }
 
@@ -51,6 +55,12 @@ class APISystemAPISyncUpdate extends APIModel {
             $this->validated_data = $this->initial_data;
         } else {
             $this->errors[] = APIResponse\get(1);
+        }
+    }
+
+    public function backup() {
+        if (isset($this->pkg_conf["persist"])) {
+            shell_exec("/usr/local/share/pfSense-pkg-API/manage.php backup");
         }
     }
 }

--- a/pfSense-pkg-API/files/etc/inc/api/models/APISystemAPIUpdate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APISystemAPIUpdate.inc
@@ -132,7 +132,7 @@ class APISystemAPIUpdate extends APIModel {
 
     private function __validate_hasync_hosts() {
         # Only validate this field if HA sync is enabled
-        if ($this->validated_data["hasync"]) {
+        if (isset($this->validated_data["hasync"])) {
             # Validate our required 'hasync_hosts' payload value
             if (isset($this->initial_data["hasync_hosts"]) and count($this->initial_data["hasync_hosts"]) > 0) {
                 # Loop through each host and ensure it is valid
@@ -150,7 +150,7 @@ class APISystemAPIUpdate extends APIModel {
 
     private function __validate_hasync_username() {
         # Only validate this field if HA sync is enabled
-        if ($this->validated_data["hasync"]) {
+        if (isset($this->validated_data["hasync"])) {
             # Validate our required 'hasync_username' payload value
             if (isset($this->initial_data["hasync_username"])) {
                 $this->validated_data["hasync_username"] = strval($this->initial_data["hasync_username"]);
@@ -162,7 +162,7 @@ class APISystemAPIUpdate extends APIModel {
 
     private function __validate_hasync_password() {
         # Only validate this field if HA sync is enabled
-        if ($this->validated_data["hasync"]) {
+        if (isset($this->validated_data["hasync"])) {
             # Validate our required 'hasync_password' payload value
             if (isset($this->initial_data["hasync_password"])) {
                 $this->validated_data["hasync_password"] = strval($this->initial_data["hasync_password"]);

--- a/pfSense-pkg-API/files/etc/inc/api/models/APISystemAPIUpdate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APISystemAPIUpdate.inc
@@ -30,8 +30,9 @@ class APISystemAPIUpdate extends APIModel {
         $this->config["installedpackages"]["package"][APITools\get_api_config()[0]]["conf"] = $this->validated_data;
         $this->write_config();
 
-        # Sync changes to HA nodes if enabled
-        $this->__sync();
+        # Backup and sync changes to HA nodes if enabled
+        $this->backup();
+        $this->sync();
 
         # Remove sensitive values
         unset($this->validated_data["server_key"]);
@@ -73,6 +74,15 @@ class APISystemAPIUpdate extends APIModel {
             $this->validated_data["enable_login_protection"] = "";
         } elseif ($this->initial_data['enable_login_protection'] === false) {
             unset($this->validated_data["enable_login_protection"]);
+        }
+    }
+
+    private function __validate_log_successful_auth() {
+        # Check for our optional 'log_successful_auth' payload value
+        if ($this->initial_data['log_successful_auth'] === true) {
+            $this->validated_data["log_successful_auth"] = "";
+        } elseif ($this->initial_data['log_successful_auth'] === false) {
+            unset($this->validated_data["log_successful_auth"]);
         }
     }
 
@@ -249,7 +259,13 @@ class APISystemAPIUpdate extends APIModel {
         }
     }
 
-    private function __sync() {
+    public function backup() {
+        if (isset($this->validated_data["persist"])) {
+            shell_exec("/usr/local/share/pfSense-pkg-API/manage.php backup");
+        }
+    }
+
+    public function sync() {
         # Use ob_start()/ob_end_clean() to prevent sync() from printing output
         ob_start();
         APITools\sync();
@@ -269,6 +285,7 @@ class APISystemAPIUpdate extends APIModel {
         $this->__validate_custom_headers();
         $this->__validate_access_list();
         $this->__validate_enable_login_protection();
+        $this->__validate_log_successful_auth();
         $this->__validate_hasync();
         $this->__validate_hasync_hosts();
         $this->__validate_hasync_username();

--- a/pfSense-pkg-API/files/usr/local/www/api/documentation/openapi.yml
+++ b/pfSense-pkg-API/files/usr/local/www/api/documentation/openapi.yml
@@ -12089,6 +12089,10 @@ paths:
                 enable_login_protection:
                   description: Enable or disable Login Protection for API authentication requests.
                   type: boolean
+                log_successful_auth:
+                  description: Enable or disable logging successful API authentication requests in syslog. This
+                    field is only applicable if `enable_login_protection` is set to `true`.
+                  type: boolean
                 hasync:
                   description: Enable or disable HA sync for API configurations.
                   type: boolean

--- a/pfSense-pkg-API/files/usr/local/www/api/index.php
+++ b/pfSense-pkg-API/files/usr/local/www/api/index.php
@@ -165,6 +165,12 @@ if (isset($_POST["save"])) {
         unset($pkg_config["enable_login_protection"]);
     }
 
+    if (!empty($_POST["log_successful_auth"])) {
+        $pkg_config["log_successful_auth"] = "";
+    } else {
+        unset($pkg_config["log_successful_auth"]);
+    }
+
     # Validate HA Sync settings if enabled
     if (!empty($_POST["hasync"])) {
         $pkg_config["hasync"] = "";
@@ -337,6 +343,16 @@ $advanced_section->addInput(new Form_Checkbox(
     system-wide, but API endpoints will not utilize Login Protection and may be more susceptible to brute force or 
     other authentication-based attacks. Login Protection can be configured system-wide under 
     <a href='/system_advanced_admin.php'>System > Advanced</a>."
+);
+$advanced_section->addInput(new Form_Checkbox(
+    'log_successful_auth',
+    'Log All Authentication',
+    'Enable Logging of All API Authentication Attempts',
+    isset($pkg_config["enable_login_protection"])
+))->setHelp(
+    "Log all API authentication attempts, even successful authentication. By default, only failed API authentication
+    attempts are logged (if API Login Protection is enabled above). This setting enforces all API authentication to
+    be logged instead. This may cause a lot of unnecessary syslog entries and is disabled by default."
 );
 $advanced_section->addInput(new Form_Checkbox(
     'hasync',

--- a/pfSense-pkg-API/files/usr/local/www/api/index.php
+++ b/pfSense-pkg-API/files/usr/local/www/api/index.php
@@ -348,7 +348,7 @@ $advanced_section->addInput(new Form_Checkbox(
     'log_successful_auth',
     'Log All Authentication',
     'Enable Logging of All API Authentication Attempts',
-    isset($pkg_config["enable_login_protection"])
+    isset($pkg_config["log_successful_auth"])
 ))->setHelp(
     "Log all API authentication attempts, even successful authentication. By default, only failed API authentication
     attempts are logged (if API Login Protection is enabled above). This setting enforces all API authentication to

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jinja2~=3.1.2
 requests~=2.28.1
-urllib3~=1.26.11
-pylint~=2.14.5
+pylint~=2.15.4
+urllib3~=1.26.12

--- a/tests/test_api_v1_system_api.py
+++ b/tests/test_api_v1_system_api.py
@@ -29,7 +29,7 @@ class APIE2ETestSystemAPI(e2e_test_framework.APIE2ETest):
                 "keybytes": 64,
                 "allowed_interfaces": ["WAN"],
                 "access_list": ["0::/0", "0.0.0.0/0"]
-            },
+            }
         },
         {
             "name": "Revert API configuration to default",
@@ -90,6 +90,48 @@ class APIE2ETestSystemAPI(e2e_test_framework.APIE2ETest):
                 "access_list": ["INVALID"]
             }
         },
+        {
+            "name": "Test custom_headers type constraint",
+            "status": 400,
+            "return": 1025,
+            "payload": {"custom_headers": "INVALID"}
+        },
+        {
+            "name": "Test custom_headers key-value type constraints",
+            "status": 400,
+            "return": 1026,
+            "payload": {"custom_headers": {0: True}}
+        },
+        {
+            "name": "Test hasync_hosts minimum constraint",
+            "status": 400,
+            "return": 1027,
+            "payload": {"hasync": True, "hasync_hosts": []}
+        },
+        {
+            "name": "Test hasync_hosts IP/FQDN constraint",
+            "status": 400,
+            "return": 1028,
+            "payload": {"hasync": True, "hasync_hosts": [True]}
+        },
+        {
+            "name": "Test hasync_username required constraint",
+            "status": 400,
+            "return": 1029,
+            "payload": {"hasync": True, "hasync_hosts": ["127.0.0.1"]}
+        },
+        {
+            "name": "Test hasync_username required",
+            "status": 400,
+            "return": 1029,
+            "payload": {"hasync": True, "hasync_hosts": ["127.0.0.1"], "hasync_username": "test"}
+        },
+        {
+            "name": "Test authmode options constraint",
+            "status": 400,
+            "return": 1021,
+            "payload": {"authmode": "INVALID"}
+        }
     ]
 
 


### PR DESCRIPTION
- Changes API Login Protection to only log failed authentication attempts by default (#287)
- Adds the `log_successful_auth` field to /api/v1/system/api and System > API page to optionally enable logging of successful authentication attempts (#287)
- Fixes bug that prevented persistent backups from being taken on /api/v1/system/api and /api/v1/system/api/sync (#288)
- Fixes validation for `hasync_*` fields in /api/v1/system/api (#290)