### PR TITLE
fix: Return list of values, even if request is make with filters

### DIFF
--- a/pfSense-pkg-API/files/etc/inc/api/framework/APIQuery.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/framework/APIQuery.inc
@@ -56,7 +56,7 @@ class APIQuery {
                     }
                     # If this query matched, add it to our new response
                     if ($match) {
-                        $q_response[$id] = $entry;
+                        $q_response[] = $entry;
                     }
                 }
             }


### PR DESCRIPTION
Goal of this PR is to fix a bug inside the response when a request is make with a query param of filtering. Indeed, these 2 requests `GET http://<ip>/api/v1/firewall/rule` and `GET http://<ip>/api/v1/firewall/rule?interface=opt1` does not returns the same schema response (response["data"] attribute)

- First one returns a list
- Second returns a key-values list

The fix will add each to the array after the filtering, without set a key:
```php
$q_response[] = $entry;
```

Current response of `GET http://<ip>/api/v1/firewall/rule`:

```json
{
  "status": "ok",
  "code": 200,
  "return": 0,
  "message": "Success",
  "data": [
    {
      "id": "",
      "tracker": "1648566482",
      "type": "pass",
      "ipprotocol": "inet6",
      "tag": "",
      "tagged": "",
      "direction": "any",
      "floating": "yes",
      "max": "",
      "max-src-nodes": "",
      "max-src-conn": "",
      "max-src-states": "",
      "statetimeout": "",
      "statetype": "keep state",
      "os": "",
      "protocol": "icmp",
      "icmptype": "echoreq,neighbradv",
      "source": {
        "any": ""
      },
      "destination": {
        "any": ""
      },
      "descr": "Pass ICMP",
      "created": {
        "time": "1648566482",
        "username": "admin@10.0.0.1 (Local Database)"
      },
      "updated": {
        "time": "1648652846",
        "username": "admin@10.0.0.1 (Local Database)"
      }
    },
    {
      "id": "",
      "tracker": "1668766582",
      "type": "pass",
      "interface": "opt1",
      "ipprotocol": "inet46",
      "max": "",
      "max-src-nodes": "",
      "max-src-conn": "",
      "max-src-states": "",
      "statetimeout": "",
      "statetype": "keep state",
      "os": "",
      "source": {
        "address": "host1"
      },
      "destination": {
        "address": "host2"
      },
      "log": "",
      "descr": "Pass 1",
      "updated": {
        "time": "1668766582",
        "username": "admin@10.0.0.1 (Local Database)"
      },
      "created": {
        "time": "1668766582",
        "username": "admin@10.0.0.1 (Local Database)"
      }
    },
    {
      "id": "",
      "tracker": "1670589717",
      "type": "pass",
      "interface": "opt1",
      "ipprotocol": "inet",
      "tag": "",
      "tagged": "",
      "max": "",
      "max-src-nodes": "",
      "max-src-conn": "",
      "max-src-states": "",
      "statetimeout": "",
      "statetype": "keep state",
      "os": "",
      "protocol": "udp",
      "source": {
        "network": "wan"
      },
      "destination": {
        "network": "wanip"
      },
      "descr": "Pass 3",
      "created": {
        "time": "1670589717",
        "username": "admin@10.0.0.1 (Local Database)"
      },
      "updated": {
        "time": "1670598444",
        "username": "admin@10.0.0.1 (Local Database)"
      }
    }
  ]
}
```


Current response of `GET http://<ip>/api/v1/firewall/rule?interface=opt1`:

```json
{
  "status": "ok",
  "code": 200,
  "return": 0,
  "message": "Success",
  "data": {
    "50": {
      "id": "",
      "tracker": "1668766582",
      "type": "pass",
      "interface": "opt1",
      "ipprotocol": "inet46",
      "max": "",
      "max-src-nodes": "",
      "max-src-conn": "",
      "max-src-states": "",
      "statetimeout": "",
      "statetype": "keep state",
      "os": "",
      "source": {
        "address": "host1"
      },
      "destination": {
        "address": "host2"
      },
      "log": "",
      "descr": "Pass 1",
      "updated": {
        "time": "1668766582",
        "username": "admin@10.0.0.1 (Local Database)"
      },
      "created": {
        "time": "1668766582",
        "username": "admin@10.0.0.1 (Local Database)"
      }
    },
    "52": {
      "id": "",
      "tracker": "1670589717",
      "type": "pass",
      "interface": "opt1",
      "ipprotocol": "inet",
      "tag": "",
      "tagged": "",
      "max": "",
      "max-src-nodes": "",
      "max-src-conn": "",
      "max-src-states": "",
      "statetimeout": "",
      "statetype": "keep state",
      "os": "",
      "protocol": "udp",
      "source": {
        "network": "wan"
      },
      "destination": {
        "network": "wanip"
      },
      "descr": "Pass 3",
      "created": {
        "time": "1670589717",
        "username": "admin@10.0.0.1 (Local Database)"
      },
      "updated": {
        "time": "1670598444",
        "username": "admin@10.0.0.1 (Local Database)"
      }
    }
  }
}
```