### PR TITLE
feature: Create a floating rule without interface

### DIFF
--- a/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallRuleCreate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallRuleCreate.inc
@@ -89,6 +89,9 @@ class APIFirewallRuleCreate extends APIModel {
             # Remove duplicates and convert back to pfSense expected format
             $this->validated_data["interface"] = array_unique($this->validated_data["interface"]);
             $this->validated_data["interface"] = implode(",", $this->validated_data["interface"]);
+        } else if ($this->initial_data["floating"] === true) {
+            # Add a floating rule without interface
+            ; // no op
         } else {
             $this->errors[] = APIResponse\get(4034);
         }


### PR DESCRIPTION
Hi,

Here is a PR to add the possiblity to create a new floating rule, without specifying interface 

Example payload (`POST api/v1/firewall/rule`):
```json
{
  "descr": "Floating Rule no interface",
  "type": "pass",
  "src": "any",
  "srcport": "any",
  "dst": "any",
  "dstport": "any",
  "protocol": "tcp",
  "floating": true,
  "interface": null,
  "disabled": false,
  "ipprotocol": "inet46",
  "log": false,
  "top": false
}
```