### PR TITLE
feat: Get filter rules: Convert some fields to booleans

### DIFF
--- a/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallRuleRead.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallRuleRead.inc
@@ -25,6 +25,15 @@ class APIFirewallRuleRead extends APIModel {
     }
 
     public function action() {
-        return APIResponse\get(0, $this->get_config("filter/rule", []));
+        $rule_array = $this->get_config("filter/rule", []);
+
+        // Convert some fields to booleans, to better convenience
+        foreach ($rule_array as $i=>$rule) {
+            $rule_array[$i]["floating"] = $rule["floating"] === "yes";
+            $rule_array[$i]["disabled"] = $rule["disabled"] === "";
+            $rule_array[$i]["log"] = $rule["log"] === "";
+        }
+
+        return APIResponse\get(0, $rule_array);
     }
 }


### PR DESCRIPTION
Hi,

Goal of this PR is to improve useability of endpoint `GET /api/firewall/rule`. Some fields can be converted to boolean instead of return empty strings. Impacted fields :

- `log`
- `floating`
- `disabled`

`GET /api/firewall/rule` before this PR:

```json
{
  "status": "ok",
  "code": 200,
  "return": 0,
  "message": "Success",
  "data": [
    {
      "id": "",
      "tracker": "1668766583",
      "type": "block",
      ...
      "disabled": "",
      "log": ""
    }
  ]
}
```

`GET /api/firewall/rule` after this PR:
```json
{
  "status": "ok",
  "code": 200,
  "return": 0,
  "message": "Success",
  "data": [
    {
      "id": "",
      "tracker": "1668766583",
      "type": "block",
      ...
      "disabled": true,
      "floating": false,
      "log": true
    }
  ]
}
```