### PR TITLE
fix: fix context in port range replaces (#327)

### DIFF
--- a/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallNATOutboundMappingCreate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallNATOutboundMappingCreate.inc
@@ -223,7 +223,7 @@ class APIFirewallNATOutboundMappingCreate extends APIModel {
             }
             # If our value is not any, replace the port range character with a - and save the value
             elseif ($this->initial_data['srcport'] !== "any") {
-                $this->validated_data["sourceport"] = str_replace(":", "-", $this->initial_data['srcport']);
+                $this->validated_data["sourceport"] = str_replace("-", ":", $this->initial_data['srcport']);
             }
         }
     }
@@ -238,7 +238,7 @@ class APIFirewallNATOutboundMappingCreate extends APIModel {
             }
             # If our value is not any, replace the port range character with a - and save the value
             elseif ($this->initial_data['dstport'] !== "any") {
-                $this->validated_data["dstport"] = str_replace(":", "-", $this->initial_data['dstport']);
+                $this->validated_data["dstport"] = str_replace("-", ":", $this->initial_data['dstport']);
             }
         }
     }

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallNATOutboundMappingUpdate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallNATOutboundMappingUpdate.inc
@@ -239,7 +239,7 @@ class APIFirewallNATOutboundMappingUpdate extends APIModel {
             }
             # If our value is not any, replace the port range character with a - and save the value
             elseif ($this->initial_data['srcport'] !== "any") {
-                $this->validated_data["sourceport"] = str_replace(":", "-", $this->initial_data['srcport']);
+                $this->validated_data["sourceport"] = str_replace("-", ":", $this->initial_data['srcport']);
             }
         }
     }
@@ -254,7 +254,7 @@ class APIFirewallNATOutboundMappingUpdate extends APIModel {
             }
             # If our value is not any, replace the port range character with a - and save the value
             elseif ($this->initial_data['dstport'] !== "any") {
-                $this->validated_data["dstport"] = str_replace(":", "-", $this->initial_data['dstport']);
+                $this->validated_data["dstport"] = str_replace("-", ":", $this->initial_data['dstport']);
             }
         }
     }


### PR DESCRIPTION
Port ranges must always be separated by :, this commit fixes the context in a few replace statements that replace the : with -