### PR TITLE
v1.5.4 Fixes

### DIFF
--- a/pfSense-pkg-API/files/etc/inc/api/framework/APIQuery.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/framework/APIQuery.inc
@@ -91,8 +91,8 @@ class APIQuery {
 
         # Only proceed if key is not excluded from queries
         if (!$this->is_excluded($q_key)) {
-            # Always prefer exact matches first
-            if ($entry[$key] === $value) {
+            # Always prefer exact matches first. Don't strict type match since the pfSense config won't store types.
+            if ($entry[$key] == $value) {
                 return true;
             }
 

--- a/pfSense-pkg-API/files/etc/inc/api/framework/APITools.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/framework/APITools.inc
@@ -345,7 +345,7 @@ function sort_nat_rules($top=false, $data=null, $field=null) {
 
     foreach ($acl as $idx => $fre) {
         # Check if top mode is enabled, if so add this item to the start of the array
-        if ($top === true and $idx === $data) {
+        if ($top == true and $idx === $data) {
             array_unshift($sort_arr, $fre);
         } else {
             $sort_arr[] = $fre;

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallNATOutboundMappingCreate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallNATOutboundMappingCreate.inc
@@ -223,7 +223,7 @@ class APIFirewallNATOutboundMappingCreate extends APIModel {
             }
             # If our value is not any, replace the port range character with a - and save the value
             elseif ($this->initial_data['srcport'] !== "any") {
-                $this->validated_data["sourceport"] = str_replace(":", "-", $this->initial_data['srcport']);
+                $this->validated_data["sourceport"] = str_replace("-", ":", $this->initial_data['srcport']);
             }
         }
     }
@@ -238,7 +238,7 @@ class APIFirewallNATOutboundMappingCreate extends APIModel {
             }
             # If our value is not any, replace the port range character with a - and save the value
             elseif ($this->initial_data['dstport'] !== "any") {
-                $this->validated_data["dstport"] = str_replace(":", "-", $this->initial_data['dstport']);
+                $this->validated_data["dstport"] = str_replace("-", ":", $this->initial_data['dstport']);
             }
         }
     }

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallNATOutboundMappingUpdate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallNATOutboundMappingUpdate.inc
@@ -239,7 +239,7 @@ class APIFirewallNATOutboundMappingUpdate extends APIModel {
             }
             # If our value is not any, replace the port range character with a - and save the value
             elseif ($this->initial_data['srcport'] !== "any") {
-                $this->validated_data["sourceport"] = str_replace(":", "-", $this->initial_data['srcport']);
+                $this->validated_data["sourceport"] = str_replace("-", ":", $this->initial_data['srcport']);
             }
         }
     }
@@ -254,7 +254,7 @@ class APIFirewallNATOutboundMappingUpdate extends APIModel {
             }
             # If our value is not any, replace the port range character with a - and save the value
             elseif ($this->initial_data['dstport'] !== "any") {
-                $this->validated_data["dstport"] = str_replace(":", "-", $this->initial_data['dstport']);
+                $this->validated_data["dstport"] = str_replace("-", ":", $this->initial_data['dstport']);
             }
         }
     }

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIStatusSystemRead.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIStatusSystemRead.inc
@@ -45,6 +45,7 @@ class APIStatusSystemRead extends APIModel {
             "temp_c" => $this->__get_temp(),
             "temp_f" => $this->__get_temp(false),
             "load_avg" => $this->__get_load_avg(),
+            "cpu_count" => (int)get_single_sysctl("hw.ncpu"),
             "mbuf_usage" => $this->__get_mbuf_usage(),
             "mem_usage" => (!is_null(mem_usage())) ? APITools\float_percent(mem_usage()) : null,
             "swap_usage" => (!is_null(swap_usage())) ? APITools\float_percent(swap_usage()) : null,

--- a/pfSense-pkg-API/files/etc/inc/api/models/APISystemCARead.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APISystemCARead.inc
@@ -31,7 +31,7 @@ class APISystemCARead extends APIModel {
 
     public function validate_payload() {
         if (!empty($this->config["ca"])) {
-            $this->validated_data["ca"] = $this->config["ca"];
+            $this->validated_data = $this->config["ca"];
         }
     }
 }

--- a/pfSense-pkg-API/files/etc/inc/api/models/APISystemCertificateRead.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APISystemCertificateRead.inc
@@ -31,7 +31,7 @@ class APISystemCertificateRead extends APIModel {
 
     public function validate_payload() {
         if (!empty($this->config["cert"])) {
-            $this->validated_data["cert"] = $this->config["cert"];
+            $this->validated_data = $this->config["cert"];
         }
     }
 }

--- a/pfSense-pkg-API/files/usr/local/www/api/documentation/openapi.yml
+++ b/pfSense-pkg-API/files/usr/local/www/api/documentation/openapi.yml
@@ -9794,6 +9794,9 @@ paths:
 
                     _Note: If you are using a failover group, the failover group must be configured to use the same_.'
                   type: string
+                server_addr:
+                  description: Sets the server IP or hostname of the OpenVPN server this client will connect to.
+                  type: string
                 local_port:
                   description: The port number upon which OpenVPN will listen for incoming connections from peers.
                     Firewall rules must allow traffic to this port and this port must be specified in the client configuration.

--- a/pfSense-pkg-API/files/usr/local/www/api/documentation/openapi.yml
+++ b/pfSense-pkg-API/files/usr/local/www/api/documentation/openapi.yml
@@ -9324,6 +9324,9 @@ paths:
 
                     _Note: If you are using a failover group, the failover group must be configured to use the same_.'
                   type: string
+                server_addr:
+                  description: Sets the server IP or hostname of the OpenVPN server this client will connect to.
+                  type: string
                 local_port:
                   description: For clients, the local port should be blank in nearly every case so that OpenVPN
                     will use a randomized local port. This behavior is more secure, but some server configurations


### PR DESCRIPTION
### Fixes
- Fixes issue where GET /api/v1/system/ca would return an associative array of CAs instead of a sequential array (#357)
- Fixes issue where GET /api/v1/system/certificate would return an associative array of certs instead of a sequential array (#357)
- Loosens type checking when sorting NAT rules (#352)
- Adds documentation for `server_addr` field on /api/v1/services/openvpn/client (#360)

### Changes
- Bumps `php-jwt` dependency to v6.7.0