### PR TITLE
v1.6.1 Fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        build:
+        include:
           - freebsd_version: FreeBSD-14.0-CURRENT
             freebsd_id: freebsd14
 
@@ -25,26 +25,26 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup FreeBSD build VM
         run: |
-          /usr/local/bin/VBoxManage controlvm ${{ matrix.build.freebsd_version }} poweroff || true
-          /usr/local/bin/VBoxManage snapshot ${{ matrix.build.freebsd_version }} restore initial
-          /usr/local/bin/VBoxManage startvm ${{ matrix.build.freebsd_version }} --type headless
+          /usr/local/bin/VBoxManage controlvm ${{ matrix.freebsd_version }} poweroff || true
+          /usr/local/bin/VBoxManage snapshot ${{ matrix.freebsd_version }} restore initial
+          /usr/local/bin/VBoxManage startvm ${{ matrix.freebsd_version }} --type headless
           sleep 5
 
       - name: Build pfSense-pkg-API on FreeBSD
         run: |
-          /usr/bin/ssh -o StrictHostKeyChecking=no ${{ matrix.build.freebsd_version }}.jaredhendrickson.com 'sudo pkill ntpd || true && sudo ntpdate pool.ntp.org || true'
-          /usr/local/bin/python3 tools/make_package.py --host ${{ matrix.build.freebsd_version }}.jaredhendrickson.com --branch ${{ env.commit_id }} --tag ${{ env.build_version }}_${{ matrix.build.freebsd_id }}
+          /usr/bin/ssh -o StrictHostKeyChecking=no ${{ matrix.freebsd_version }}.jaredhendrickson.com 'sudo pkill ntpd || true && sudo ntpdate pool.ntp.org || true'
+          /usr/local/bin/python3 tools/make_package.py --host ${{ matrix.freebsd_version }}.jaredhendrickson.com --branch ${{ env.commit_id }} --tag ${{ env.build_version }}_${{ matrix.freebsd_id }}
 
       - name: Teardown FreeBSD build VM
         if: "${{ always() }}"
         run: |
-          /usr/local/bin/VBoxManage controlvm ${{ matrix.build.freebsd_version }} poweroff || true
-          /usr/local/bin/VBoxManage snapshot ${{matrix.build.freebsd_version}} restore initial
+          /usr/local/bin/VBoxManage controlvm ${{ matrix.freebsd_version }} poweroff || true
+          /usr/local/bin/VBoxManage snapshot ${{matrix.freebsd_version}} restore initial
 
       - uses: actions/upload-artifact@v3
         with:
-          name: pfSense-pkg-API-${{ env.build_version }}_${{ matrix.build.freebsd_id }}.pkg
-          path: pfSense-pkg-API-${{ env.build_version }}_${{ matrix.build.freebsd_id }}.pkg
+          name: pfSense-pkg-API-${{ env.build_version }}_${{ matrix.freebsd_id }}.pkg
+          path: pfSense-pkg-API-${{ env.build_version }}_${{ matrix.freebsd_id }}.pkg
 
   e2e_tests:
     runs-on: self-hosted
@@ -54,19 +54,19 @@ jobs:
       matrix:
         include:
           - pfsense_version: pfSense-2.7.0-RELEASE
-            freebsd_version: FreeBSD-14.0-CURRENT
+            freebsd_id: freebsd14
           - pfsense_version: pfSense-23.01-RELEASE
-            freebsd_version: FreeBSD-14.0-CURRENT
+            freebsd_id: freebsd14
           - pfsense_version: pfSense-23.05-RELEASE
-            freebsd_version: FreeBSD-14.0-CURRENT
+            freebsd_id: freebsd14
         
     steps:
       - uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v3
         with:
-          name: pfSense-pkg-API-${{ env.build_version }}_${{ matrix.build.freebsd_id }}.pkg
-          path: pfSense-pkg-API-${{ env.build_version }}_${{ matrix.build.freebsd_id }}.pkg
+          name: pfSense-pkg-API-${{ env.build_version }}_${{ matrix.freebsd_id }}.pkg
+          path: pfSense-pkg-API-${{ env.build_version }}_${{ matrix.freebsd_id }}.pkg
 
       - name: Setup pfSense VM
         run: |
@@ -80,11 +80,11 @@ jobs:
         run: |
           pfsense-vshell --host ${{ matrix.pfsense_version }}.jaredhendrickson.com -u admin -p pfsense -c 'pfSsh.php playback enablesshd' -k
           pfsense-vshell --host ${{ matrix.pfsense_version }}.jaredhendrickson.com -u admin -p pfsense -c "mkdir /root/.ssh/ && echo $(cat ~/.ssh/id_rsa.pub) > /root/.ssh/authorized_keys" -k
-          scp -o StrictHostKeyChecking=no pfSense-pkg-API-${{ env.build_version }}_${{ matrix.build.freebsd_id }}.pkg/pfSense-pkg-API-${{ env.build_version }}_${{ matrix.build.freebsd_id }}.pkg admin@${{ matrix.pfsense_version }}.jaredhendrickson.com:/tmp/
+          scp -o StrictHostKeyChecking=no pfSense-pkg-API-${{ env.build_version }}_${{ matrix.freebsd_id }}.pkg/pfSense-pkg-API-${{ env.build_version }}_${{ matrix.freebsd_id }}.pkg admin@${{ matrix.pfsense_version }}.jaredhendrickson.com:/tmp/
 
       - name: Install pfSense-pkg-API on pfSense
         run: |
-          /usr/local/bin/pfsense-vshell --host ${{ matrix.pfsense_version }}.jaredhendrickson.com --no_verify -c "pkg -C /dev/null add /tmp/pfSense-pkg-API-${{ env.build_version }}_${{ matrix.build.freebsd_id }}.pkg" -u admin -p pfsense
+          /usr/local/bin/pfsense-vshell --host ${{ matrix.pfsense_version }}.jaredhendrickson.com --no_verify -c "pkg -C /dev/null add /tmp/pfSense-pkg-API-${{ env.build_version }}_${{ matrix.freebsd_id }}.pkg" -u admin -p pfsense
           /usr/local/bin/pfsense-vshell --host ${{ matrix.pfsense_version }}.jaredhendrickson.com --no_verify -c '/etc/rc.restart_webgui' -u admin -p pfsense || true
           sleep 10
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,33 +17,34 @@ jobs:
 
     strategy:
       matrix:
-        freebsd_version: 
-          - FreeBSD-14.0-CURRENT
-        
+        build:
+          - freebsd_version: FreeBSD-14.0-CURRENT
+            freebsd_id: freebsd14
+
     steps:
       - uses: actions/checkout@v3
       - name: Setup FreeBSD build VM
         run: |
-          /usr/local/bin/VBoxManage controlvm ${{ matrix.freebsd_version }} poweroff || true
-          /usr/local/bin/VBoxManage snapshot ${{ matrix.freebsd_version }} restore initial
-          /usr/local/bin/VBoxManage startvm ${{ matrix.freebsd_version }} --type headless
+          /usr/local/bin/VBoxManage controlvm ${{ matrix.build.freebsd_version }} poweroff || true
+          /usr/local/bin/VBoxManage snapshot ${{ matrix.build.freebsd_version }} restore initial
+          /usr/local/bin/VBoxManage startvm ${{ matrix.build.freebsd_version }} --type headless
           sleep 5
 
       - name: Build pfSense-pkg-API on FreeBSD
         run: |
-          /usr/bin/ssh -o StrictHostKeyChecking=no ${{ matrix.freebsd_version }}.jaredhendrickson.com 'sudo pkill ntpd || true && sudo ntpdate pool.ntp.org || true'
-          /usr/local/bin/python3 tools/make_package.py --host ${{ matrix.freebsd_version }}.jaredhendrickson.com --branch ${{ env.commit_id }} --tag ${{ env.build_version }}_${{ matrix.freebsd_version }}
+          /usr/bin/ssh -o StrictHostKeyChecking=no ${{ matrix.build.freebsd_version }}.jaredhendrickson.com 'sudo pkill ntpd || true && sudo ntpdate pool.ntp.org || true'
+          /usr/local/bin/python3 tools/make_package.py --host ${{ matrix.build.freebsd_version }}.jaredhendrickson.com --branch ${{ env.commit_id }} --tag ${{ env.build_version }}_${{ matrix.build.freebsd_id }}
 
       - name: Teardown FreeBSD build VM
         if: "${{ always() }}"
         run: |
-          /usr/local/bin/VBoxManage controlvm ${{ matrix.freebsd_version }} poweroff || true
-          /usr/local/bin/VBoxManage snapshot ${{matrix.freebsd_version}} restore initial
+          /usr/local/bin/VBoxManage controlvm ${{ matrix.build.freebsd_version }} poweroff || true
+          /usr/local/bin/VBoxManage snapshot ${{matrix.build.freebsd_version}} restore initial
 
       - uses: actions/upload-artifact@v3
         with:
-          name: pfSense-pkg-API-${{ env.build_version }}_${{ matrix.freebsd_version }}.pkg
-          path: pfSense-pkg-API-${{ env.build_version }}_${{ matrix.freebsd_version }}.pkg
+          name: pfSense-pkg-API-${{ env.build_version }}_${{ matrix.build.freebsd_id }}.pkg
+          path: pfSense-pkg-API-${{ env.build_version }}_${{ matrix.build.freebsd_id }}.pkg
 
   e2e_tests:
     runs-on: self-hosted
@@ -64,8 +65,8 @@ jobs:
 
       - uses: actions/download-artifact@v3
         with:
-          name: pfSense-pkg-API-${{ env.build_version }}_${{ matrix.freebsd_version }}.pkg
-          path: pfSense-pkg-API-${{ env.build_version }}_${{ matrix.freebsd_version }}.pkg
+          name: pfSense-pkg-API-${{ env.build_version }}_${{ matrix.build.freebsd_id }}.pkg
+          path: pfSense-pkg-API-${{ env.build_version }}_${{ matrix.build.freebsd_id }}.pkg
 
       - name: Setup pfSense VM
         run: |
@@ -79,11 +80,11 @@ jobs:
         run: |
           pfsense-vshell --host ${{ matrix.pfsense_version }}.jaredhendrickson.com -u admin -p pfsense -c 'pfSsh.php playback enablesshd' -k
           pfsense-vshell --host ${{ matrix.pfsense_version }}.jaredhendrickson.com -u admin -p pfsense -c "mkdir /root/.ssh/ && echo $(cat ~/.ssh/id_rsa.pub) > /root/.ssh/authorized_keys" -k
-          scp -o StrictHostKeyChecking=no pfSense-pkg-API-${{ env.build_version }}_${{ matrix.freebsd_version }}.pkg/pfSense-pkg-API-${{ env.build_version }}_${{ matrix.freebsd_version }}.pkg admin@${{ matrix.pfsense_version }}.jaredhendrickson.com:/tmp/
+          scp -o StrictHostKeyChecking=no pfSense-pkg-API-${{ env.build_version }}_${{ matrix.build.freebsd_id }}.pkg/pfSense-pkg-API-${{ env.build_version }}_${{ matrix.build.freebsd_id }}.pkg admin@${{ matrix.pfsense_version }}.jaredhendrickson.com:/tmp/
 
       - name: Install pfSense-pkg-API on pfSense
         run: |
-          /usr/local/bin/pfsense-vshell --host ${{ matrix.pfsense_version }}.jaredhendrickson.com --no_verify -c "pkg -C /dev/null add /tmp/pfSense-pkg-API-${{ env.build_version }}_${{ matrix.freebsd_version }}.pkg" -u admin -p pfsense
+          /usr/local/bin/pfsense-vshell --host ${{ matrix.pfsense_version }}.jaredhendrickson.com --no_verify -c "pkg -C /dev/null add /tmp/pfSense-pkg-API-${{ env.build_version }}_${{ matrix.build.freebsd_id }}.pkg" -u admin -p pfsense
           /usr/local/bin/pfsense-vshell --host ${{ matrix.pfsense_version }}.jaredhendrickson.com --no_verify -c '/etc/rc.restart_webgui' -u admin -p pfsense || true
           sleep 10
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        build_versions:
+        include:
           - freebsd_version: FreeBSD-14.0-CURRENT
             pfsense_version: 2.7
           - freebsd_version: FreeBSD-14.0-CURRENT
@@ -25,23 +25,23 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup FreeBSD build VM
         run: |
-          /usr/local/bin/VBoxManage controlvm ${{ matrix.build_versions.freebsd_version }} poweroff || true
-          /usr/local/bin/VBoxManage snapshot ${{ matrix.build_versions.freebsd_version }} restore initial
-          /usr/local/bin/VBoxManage startvm ${{ matrix.build_versions.freebsd_version }} --type headless
+          /usr/local/bin/VBoxManage controlvm ${{ matrix.freebsd_version }} poweroff || true
+          /usr/local/bin/VBoxManage snapshot ${{ matrix.freebsd_version }} restore initial
+          /usr/local/bin/VBoxManage startvm ${{ matrix.freebsd_version }} --type headless
           sleep 5
 
       - name: Build pfSense-pkg-API on FreeBSD
         run: |
-          /usr/bin/ssh -o StrictHostKeyChecking=no ${{ matrix.build_versions.freebsd_version }}.jaredhendrickson.com 'sudo pkill ntpd || true && sudo ntpdate pool.ntp.org || true'
-          /usr/local/bin/python3 tools/make_package.py --host ${{ matrix.build_versions.freebsd_version }}.jaredhendrickson.com --branch ${{ github.sha }} --tag ${{ github.ref_name }} --filename pfSense-${{ matrix.build_versions.pfsense_version }}-pkg-API.pkg
+          /usr/bin/ssh -o StrictHostKeyChecking=no ${{ matrix.freebsd_version }}.jaredhendrickson.com 'sudo pkill ntpd || true && sudo ntpdate pool.ntp.org || true'
+          /usr/local/bin/python3 tools/make_package.py --host ${{ matrix.freebsd_version }}.jaredhendrickson.com --branch ${{ github.sha }} --tag ${{ github.ref_name }} --filename pfSense-${{ matrix.pfsense_version }}-pkg-API.pkg
 
       - name: Teardown FreeBSD build VM
         if: "${{ always() }}"
         run: |
-          /usr/local/bin/VBoxManage controlvm ${{ matrix.build_versions.freebsd_version }} poweroff || true
-          /usr/local/bin/VBoxManage snapshot ${{matrix.build_versions.freebsd_version}} restore initial
+          /usr/local/bin/VBoxManage controlvm ${{ matrix.freebsd_version }} poweroff || true
+          /usr/local/bin/VBoxManage snapshot ${{matrix.freebsd_version}} restore initial
 
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
-          files: pfSense-${{ matrix.build_versions.pfsense_version }}-pkg-API.pkg
+          files: pfSense-${{ matrix.pfsense_version }}-pkg-API.pkg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+concurrency: build
+
+jobs:
+  build:
+    runs-on: self-hosted
+
+    strategy:
+      matrix:
+        build_versions:
+          - freebsd_version: FreeBSD-14.0-CURRENT
+            pfsense_version: 2.7
+          - freebsd_version: FreeBSD-14.0-CURRENT
+            pfsense_version: 23.05
+          - freebsd_version: FreeBSD-14.0-CURRENT
+            pfsense_version: 23.01
+        
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup FreeBSD build VM
+        run: |
+          /usr/local/bin/VBoxManage controlvm ${{ matrix.build_versions.freebsd_version }} poweroff || true
+          /usr/local/bin/VBoxManage snapshot ${{ matrix.build_versions.freebsd_version }} restore initial
+          /usr/local/bin/VBoxManage startvm ${{ matrix.build_versions.freebsd_version }} --type headless
+          sleep 5
+
+      - name: Build pfSense-pkg-API on FreeBSD
+        run: |
+          /usr/bin/ssh -o StrictHostKeyChecking=no ${{ matrix.build_versions.freebsd_version }}.jaredhendrickson.com 'sudo pkill ntpd || true && sudo ntpdate pool.ntp.org || true'
+          /usr/local/bin/python3 tools/make_package.py --host ${{ matrix.build_versions.freebsd_version }}.jaredhendrickson.com --branch ${{ github.sha }} --tag ${{ github.ref_name }} --filename pfSense-${{ matrix.build_versions.pfsense_version }}-pkg-API.pkg
+
+      - name: Teardown FreeBSD build VM
+        if: "${{ always() }}"
+        run: |
+          /usr/local/bin/VBoxManage controlvm ${{ matrix.build_versions.freebsd_version }} poweroff || true
+          /usr/local/bin/VBoxManage snapshot ${{matrix.build_versions.freebsd_version}} restore initial
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: pfSense-${{ matrix.build_versions.pfsense_version }}-pkg-API.pkg

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallAliasEntryCreate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallAliasEntryCreate.inc
@@ -111,24 +111,19 @@ class APIFirewallAliasEntryCreate extends APIModel {
     }
 
     public function __validate_detail() {
+        # Get a list of the new addresses and details requested
+        $this->initial_data["address"] = $this->__value_to_array($this->initial_data["address"]);
         $this->initial_data["detail"] = $this->__value_to_array($this->initial_data["detail"]);
-        $this->validated_data["detail"] = ($this->validated_data["detail"]) ? explode("||", $this->validated_data["detail"]) : [];
-        $this->validated_data["detail"] = $this->__value_to_array($this->validated_data["detail"]);
-        $address = ($this->validated_data["address"]) ? explode(" ", $this->validated_data["address"]) : [];
+        $this->validated_data["detail"] = $this->__value_to_array(explode("||", $this->validated_data["detail"]));
 
-        # If we have less detail values than address values, add some defaults
-        while(true) {
-            # Check if we have the correct number of detail values
-            if (count($this->initial_data["detail"]) < count($address)) {
+        # Ensure the number of addresses is greater than or equal to the number details
+        if (count($this->initial_data["address"]) >= count($this->initial_data["detail"])) {
+            # Add automatic generated details if there are more addresses than details
+            while (count($this->initial_data["address"]) > count($this->initial_data["detail"])) {
                 $this->initial_data["detail"][] = "Entry added " . date('r');
-            } else {
-                break;
             }
-        }
 
-        # Ensure the number of detail values is less than or equal to the number of address values
-        if (count($this->initial_data["detail"]) <= count($address)) {
-            # Loop through each alias detail and ensure it is a string
+            # Loop through each ali:as detail and ensure it is a string
             foreach ($this->initial_data["detail"] as $detail) {
                 if (is_string($detail)) {
                     $this->validated_data["detail"][] = $detail;
@@ -168,7 +163,6 @@ class APIFirewallAliasEntryCreate extends APIModel {
                 return [];
             } else {
                 return [$value];
-
             }
         } else {
             return $value;

--- a/pfSense-pkg-API/files/etc/inc/api/models/APISystemAPIVersionRead.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APISystemAPIVersionRead.inc
@@ -35,7 +35,7 @@ class APISystemAPIVersionRead extends APIModel {
 
     public static function get_api_version() {
         # Pull the raw pkg info for the API package into an array for each line
-        $pkg_info = explode(PHP_EOL, shell_exec("pkg info pfSense-pkg-API"));
+        $pkg_info = explode(PHP_EOL, shell_exec("pkg-static info pfSense-pkg-API"));
 
         # Loop through each line and check the version
         foreach ($pkg_info as $pkg_line) {

--- a/tests/test_api_v1_firewall_alias.py
+++ b/tests/test_api_v1_firewall_alias.py
@@ -146,6 +146,17 @@ class APIE2ETestFirewallAlias(e2e_test_framework.APIE2ETest):
                 "type": "port",
                 "address": ["!@#!@#!@#"]
             }
+        },
+        {
+            "name": "Check alias entry detail maximum constraint",
+            "status": 400,
+            "return": 4106,
+            "req_data": {
+                "name": "TEST",
+                "type": "port",
+                "address": [80],
+                "detail": ["HTTP", "One-too-many!"]
+            }
         }
     ]
     put_tests = [

--- a/tools/make_package.py
+++ b/tools/make_package.py
@@ -125,15 +125,23 @@ class MakePackage:
             v=self.port_version,
             r="_" + self.port_revision if self.port_revision != "0" else ""
         )
-        self.run_scp_cmd(src, ".")
+        self.run_scp_cmd(src, f"{self.args.filename}")
 
     def __start_argparse__(self):
         # Custom tag type for argparse
         def tag(value_string):
-            if "." in value_string and "_" in value_string:
-                return value_string
+            if "." not in value_string:
+                raise argparse.ArgumentTypeError(f"{value_string} is not a semantic version tag")
 
-            raise argparse.ArgumentTypeError(f"{value_string} is not a semantic version tag")
+            # Remove the leading 'v' if present
+            if value_string.startswith("v"):
+                value_string = value_string[1:]
+
+            # Convert the patch section to be prefixed with _ if it is prefixed with .
+            if value_string.split(".") == 3:
+                value_string = value_string[::-1].replace(".", "_", 1)[::-1]
+
+            return value_string
 
         parser = argparse.ArgumentParser(
             description="Build the pfSense API on FreeBSD"
@@ -165,6 +173,14 @@ class MakePackage:
             type=tag,
             required=True,
             help="The version tag to use when building."
+        )
+        parser.add_argument(
+            '--filename', '-f',
+            dest="filename",
+            type=str,
+            default=".",
+            required=False,
+            help="The filename to use for the package file."
         )
         self.args = parser.parse_args()
 

--- a/tools/make_package.py
+++ b/tools/make_package.py
@@ -131,14 +131,14 @@ class MakePackage:
         # Custom tag type for argparse
         def tag(value_string):
             if "." not in value_string:
-                raise argparse.ArgumentTypeError(f"{value_string} is not a semantic version tag")
+                raise ValueError(f"{value_string} is not a semantic version tag")
 
             # Remove the leading 'v' if present
             if value_string.startswith("v"):
                 value_string = value_string[1:]
 
             # Convert the patch section to be prefixed with _ if it is prefixed with .
-            if value_string.split(".") == 3:
+            if len(value_string.split(".")) == 3:
                 value_string = value_string[::-1].replace(".", "_", 1)[::-1]
 
             return value_string


### PR DESCRIPTION
### Fixes
- Fixes issue with POST /api/v1/firewall/alias/entry that allowed an extra alias `detail` item to be appended. #374 

### Changes
- Uses `pkg-static` for API version lookups instead of `pkg`. #373 