### PR TITLE
v1.6.2 Fixes

### DIFF
--- a/pfSense-pkg-API/files/etc/inc/api/framework/APIResponse.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/framework/APIResponse.inc
@@ -1625,12 +1625,6 @@ function get($id, $data=[], $all=false) {
             "return" => $id,
             "message" => "IPsec remote gateway must be IPv6 address when protocol is set to 'inet6'"
         ],
-        2169 => [
-            "status" => "bad request",
-            "code" => 400,
-            "return" => $id,
-            "message" => "IPsec remote gateway cannot be a hostname unless protocol is set to 'both'"
-        ],
         2170 => [
             "status" => "bad request",
             "code" => 400,

--- a/pfSense-pkg-API/files/etc/inc/api/framework/APITools.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/framework/APITools.inc
@@ -1133,6 +1133,11 @@ function is_assoc_array($array, $strict_seq=false) {
 function api_request($url, $method, $data=[], $headers=[], $username="", $password="") {
     # Format data and headers
     $data = json_encode($data);
+
+    # Ensure headers is always an array
+    if (!is_array($headers)) {
+        $headers = [];
+    }
     $headers["Content-Type"] = "application/json";
     $headers["Content-Length"] = strlen($data);
 

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIAccessTokenCreate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIAccessTokenCreate.inc
@@ -22,6 +22,7 @@ class APIAccessTokenCreate extends APIModel {
         parent::__construct();
         $this->set_auth_mode = "local";
         $this->retain_read_mode = false;
+        $this->privileges = [];
     }
 
     # Validate our API configurations auth mode (must be JWT)

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallNATOutboundMappingCreate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallNATOutboundMappingCreate.inc
@@ -36,7 +36,7 @@ class APIFirewallNATOutboundMappingCreate extends APIModel {
 
     public function action() {
         # Add our new configuration
-        $this->id = count($this->get_config("nat/outbound/rule"));
+        $this->id = $this->get_next_id($this->get_config("nat/outbound/rule"));
         $this->set_config("nat/outbound/rule/{$this->id}", $this->validated_data);
         APITools\sort_nat_rules($this->initial_data["top"], $this->id, "outbound");
         $this->write_config();

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallNATOutboundMappingCreate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallNATOutboundMappingCreate.inc
@@ -36,7 +36,7 @@ class APIFirewallNATOutboundMappingCreate extends APIModel {
 
     public function action() {
         # Add our new configuration
-        $this->id = $this->get_next_id($this->get_config("nat/outbound/rule"));
+        $this->id = $this->get_next_id("nat/outbound/rule");
         $this->set_config("nat/outbound/rule/{$this->id}", $this->validated_data);
         APITools\sort_nat_rules($this->initial_data["top"], $this->id, "outbound");
         $this->write_config();

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIServicesIPsecPhase1Create.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIServicesIPsecPhase1Create.inc
@@ -167,10 +167,6 @@ class APIServicesIPsecPhase1Create extends APIModel {
             elseif (is_ipaddrv4($this->initial_data["remote-gateway"]) and $this->validated_data["protocol"] === "inet6") {
                 $this->errors[] = APIResponse\get(2168);
             }
-            # For domain name remote gateways, ensure the protocol is 'both'
-            elseif (is_fqdn($this->initial_data["remote-gateway"]) and $this->validated_data["protocol"] !== "both") {
-                $this->errors[] = APIResponse\get(2169);
-            }
             # Ensure remote gateway is not already in use
             elseif ($this->is_ipsec_remote_gateway_in_use($this->initial_data["remote-gateway"])) {
                 $this->errors[] = APIResponse\get(2170);

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIServicesIPsecPhase1Update.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIServicesIPsecPhase1Update.inc
@@ -245,10 +245,6 @@ class APIServicesIPsecPhase1Update extends APIModel {
             elseif (is_ipaddrv4($this->initial_data["remote-gateway"]) and $this->validated_data["protocol"] === "inet6") {
                 $this->errors[] = APIResponse\get(2168);
             }
-            # For domain name remote gateways, ensure the protocol is 'both'
-            elseif (is_fqdn($this->initial_data["remote-gateway"]) and $this->validated_data["protocol"] !== "both") {
-                $this->errors[] = APIResponse\get(2169);
-            }
             # Ensure remote gateway is not already in use
             elseif ($this->is_ipsec_remote_gateway_in_use($this->initial_data["remote-gateway"])) {
                 $this->errors[] = APIResponse\get(2170);

--- a/tests/e2e_test_framework/__init__.py
+++ b/tests/e2e_test_framework/__init__.py
@@ -367,6 +367,8 @@ class APIE2ETest:
         :param needs_privs: (bool) whether or not the request requires privileges
         :return: (boolean) returns true if the privilege authorized the request
         """
+        # pylint: disable=too-many-arguments
+
         # Create/update the test user with no privileges to start and make a request
         self.create_or_update_user(username, password, [])
         no_priv_resp = self.make_request(

--- a/tests/e2e_test_framework/__init__.py
+++ b/tests/e2e_test_framework/__init__.py
@@ -357,18 +357,15 @@ class APIE2ETest:
         # Otherwise, raise an error
         raise ConnectionError(f"Failed to run '{cmd}' at '{self.format_url(test_params['uri'])}'")
 
-    def is_priv_allowed(self, method, username, password, privs, needs_privs=True):
+    def is_priv_allowed(self, method, username, password, priv):
         """
         Makes a test API call to check if a specified privilege authorizes the API call
         :param method: (string) the method to use when testing
         :param username: (string) the username to create/update and use for tests
         :param password: (string) the password to create/update and use for tests
-        :param privs: (array) the array of privs to assign the user and test
-        :param needs_privs: (bool) whether or not the request requires privileges
+        :param priv: (string) the priv to assign the user and test
         :return: (boolean) returns true if the privilege authorized the request
         """
-        # pylint: disable=too-many-arguments
-
         # Create/update the test user with no privileges to start and make a request
         self.create_or_update_user(username, password, [])
         no_priv_resp = self.make_request(
@@ -378,7 +375,7 @@ class APIE2ETest:
         )
 
         # Create the test user with no privileges to start and make a request
-        self.create_or_update_user(username, password, privs)
+        self.create_or_update_user(username, password, [priv])
         priv_resp = self.make_request(
             method,
             test_params={"username": username, "password": password, "req_data": {"_action_bypass": True}},
@@ -388,8 +385,8 @@ class APIE2ETest:
         # Delete the test user
         self.delete_user(username)
 
-        # Ensure unprivileged request returned a 403 if needed, and the privileged request didn't
-        if (no_priv_resp.status_code == 403 or not needs_privs) and priv_resp.status_code != 403:
+        # Ensure unprivileged reqeust returned a 403 and the privileged request didn't
+        if no_priv_resp.status_code == 403 and priv_resp.status_code != 403:
             return True
 
         return False
@@ -416,22 +413,12 @@ class APIE2ETest:
                     test_params = {"name": f"Checking privilege '{privilege}' acceptance"}
 
                     # Check if the privilege was allowed
-                    if self.is_priv_allowed(method.upper(), username, password, [privilege]):
+                    if self.is_priv_allowed(method.upper(), username, password, privilege):
                         print(self.__format_msg__(method.upper(), test_params, "Response is valid", mode="ok"))
                     else:
                         msg = f"Expected API to authorize call with privilege '{privilege}'"
                         print(self.__format_msg__(method.upper(), test_params, msg))
                         self.exit_code = 1
-            # If we don't have privileges, ensure the endpoint doesn't require privileges
-            else:
-                # Check if the privilege was allowed
-                if self.is_priv_allowed(method.upper(), username, password, [], needs_privs=False):
-                    print(self.__format_msg__(method.upper(), test_params, "Response is valid", mode="ok"))
-                else:
-                    msg = "Expected API to authorize call with out privilege privileges"
-                    print(self.__format_msg__(method.upper(), test_params, msg))
-                    self.exit_code = 1
-
 
     @staticmethod
     def has_json_response(resp):

--- a/tests/e2e_test_framework/__init__.py
+++ b/tests/e2e_test_framework/__init__.py
@@ -426,7 +426,7 @@ class APIE2ETest:
                 if self.is_priv_allowed(method.upper(), username, password, [], needs_privs=False):
                     print(self.__format_msg__(method.upper(), test_params, "Response is valid", mode="ok"))
                 else:
-                    msg = f"Expected API to authorize call with out privilege privileges"
+                    msg = "Expected API to authorize call with out privilege privileges"
                     print(self.__format_msg__(method.upper(), test_params, msg))
                     self.exit_code = 1
 

--- a/tests/test_api_v1_access_token.py
+++ b/tests/test_api_v1_access_token.py
@@ -19,6 +19,7 @@ import e2e_test_framework
 class APIE2ETestAccessToken(e2e_test_framework.APIE2ETest):
     """Class used to test the /api/v1/access_token endpoint."""
     uri = "/api/v1/access_token"
+    post_privilges = []
     post_tests = [
         {
             "name": "Change auth mode to local to test token-based auth restriction",

--- a/tests/test_api_v1_services_ipsec_phase1.py
+++ b/tests/test_api_v1_services_ipsec_phase1.py
@@ -198,28 +198,6 @@ class APIE2ETestServicesIPsecPhase1(e2e_test_framework.APIE2ETest):
             }
         },
         {
-            "name": "Check remote-gateway domain only when protocol is 'both' constraint (inet)",
-            "status": 400,
-            "return": 2169,
-            "req_data": {
-                "iketype": "ikev2",
-                "protocol": "inet",
-                "interface": "wan",
-                "remote-gateway": "example.com"
-            }
-        },
-        {
-            "name": "Check remote-gateway domain only when protocol is 'both' constraint (inet6)",
-            "status": 400,
-            "return": 2169,
-            "req_data": {
-                "iketype": "ikev2",
-                "protocol": "inet6",
-                "interface": "wan",
-                "remote-gateway": "example.com"
-            }
-        },
-        {
             "name": "Check remote gateway unique constraint",
             "status": 400,
             "return": 2170,


### PR DESCRIPTION
### Fixes
- Fixes issue where API sync with no headers threw fatal errors (fixes #380)
- Relaxes input validation for `remote-gateway` field on /api/v1/services/ipsec/phase1 (fixes #382)
- Fixes an issue where client were unable to obtain access tokens via API without `page-all` privileges (fixes #384)
- Fixes an issue where an error was thrown when attempting to create new outbound NAT mappings when no mappings exist initially (fixes #385)