### PR TITLE
Package is no longer architecture specific

### DIFF
--- a/tools/templates/Makefile.j2
+++ b/tools/templates/Makefile.j2
@@ -14,6 +14,7 @@ NO_BUILD=yes
 NO_MTREE=yes
 SUB_FILES=pkg-install pkg-deinstall
 SUB_LIST=PORTNAME=${PORTNAME}
+NO_ARCH=yes
 
 do-extract:
     ${MKDIR} ${WRKSRC}


### PR DESCRIPTION
This is to resolve this issue: https://github.com/jaredhendrickson13/pfsense-api/issues/239
Netgate devices run on arm, and by default FreeBSD will make the package specific to whatever architecture you build it on. By adding `NO_ARCH=yes` the package will not be architecture specific and so it won't require that you force install. It also allows you to do automatic updates.

You might have thought that Netgate would get around to making their own api for pfsense+ like you mentioned in [this issue](https://github.com/jaredhendrickson13/pfsense-api/issues/140), sadly not. 

