### PR TITLE
v1.6.3 Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@ are made preventing the need for a reboot. All this results in the fastest, safe
 <details>
     <summary>Supported pfSense Versions</summary>
 
-  - pfSense CE 2.7.0 (AMD64)
-  - pfSense Plus 23.01 (AMD64)
-  - pfSense Plus 23.05 (AMD64)
+  - pfSense CE 2.7.0 (amd64)
+  - pfSense Plus 23.01 (amd64)
+  - pfSense Plus 23.05 (amd64)
 
-    ---
+  _This package is not supported on other architectures such as arm64 and aarch64. However, the package should still
+  install and operate on these systems. Compatibility on unsupported systems is not guaranteed and is at your own risk._
+  ---
   
 </details>
 

--- a/pfSense-pkg-API/files/etc/inc/api/models/APISystemAPIVersionRead.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APISystemAPIVersionRead.inc
@@ -66,10 +66,7 @@ class APISystemAPIVersionRead extends APIModel {
     }
 
     public static function is_update_available() {
-        # Check if the current version is less than the latest version
-        $curr_ver_num = intval(str_replace(".", "", self::get_api_version()));
-        $latest_ver_num = intval(str_replace(".", "", self::get_latest_api_version()));
-        return $curr_ver_num < $latest_ver_num;
+        return version_compare(self::get_api_version(), self::get_latest_api_version(), operator: "<");
     }
 
     public static function get_github_releases() {


### PR DESCRIPTION
- Relaxes architecture requirement for package install.
- Fixes issue where API version comparisons fail on PHP 8+.