### PR TITLE
v1.6.4 Fixes

### DIFF
--- a/pfSense-pkg-API/files/usr/local/share/pfSense-pkg-API/manage.php
+++ b/pfSense-pkg-API/files/usr/local/share/pfSense-pkg-API/manage.php
@@ -102,7 +102,7 @@ function revert($version) {
     if($headers && strpos($headers[0], '302')) {
         echo "done.".PHP_EOL;
         echo shell_exec("/usr/sbin/pkg delete -y pfSense-pkg-API");
-        echo shell_exec("/usr/sbin/pkg -C /dev/null add ".$url);
+        echo shell_exec("/usr/sbin/pkg -C /dev/null add " . escapeshellarg($url));
         echo shell_exec("/etc/rc.restart_webgui");
     } else {
         echo "no package found.".PHP_EOL;

--- a/pfSense-pkg-API/files/usr/local/www/api/update/index.php
+++ b/pfSense-pkg-API/files/usr/local/www/api/update/index.php
@@ -59,7 +59,7 @@ $curr_ver_msg = (APISystemAPIVersionRead::is_update_available()) ? " - Update av
 # On update POST, start the update process
 if ($_POST["update"] and !empty($_POST["version"])) {
     # Start the update process in the background and print notice
-    shell_exec("nohup pfsense-api revert ".$_POST["version"]." > /dev/null &");
+    shell_exec("nohup pfsense-api revert ".escapeshellarg($_POST["version"])." > /dev/null &");
     print_apply_result_box(0, "\nAPI update process has started and is running in the background. Check back in a few minutes.");
 }
 


### PR DESCRIPTION
### Fixes
- Addresses an issue where the `revert` cli command did not properly escape input
- Fixes an issue where the identified version was not escaped during API updates.