### PR TITLE
v1.7.0 Fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,8 @@ jobs:
         include:
           - pfsense_version: pfSense-2.7.1-RELEASE
             freebsd_id: freebsd14
+          - pfsense_version: pfSense-2.7.2-RELEASE
+            freebsd_id: freebsd14
         
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,11 +53,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - pfsense_version: pfSense-2.7.0-RELEASE
-            freebsd_id: freebsd14
-          - pfsense_version: pfSense-23.01-RELEASE
-            freebsd_id: freebsd14
-          - pfsense_version: pfSense-23.05-RELEASE
+          - pfsense_version: pfSense-2.7.1-RELEASE
             freebsd_id: freebsd14
         
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,7 @@ jobs:
           - freebsd_version: FreeBSD-14.0-CURRENT
             pfsense_version: 2.7
           - freebsd_version: FreeBSD-14.0-CURRENT
-            pfsense_version: 23.05
-          - freebsd_version: FreeBSD-14.0-CURRENT
-            pfsense_version: 23.01
+            pfsense_version: 23.09
         
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ are made preventing the need for a reboot. All this results in the fastest, safe
     <summary>Supported pfSense Versions</summary>
 
   - pfSense CE 2.7.1 (amd64)
+  - pfSense CE 2.7.2 (amd64)
   - pfSense Plus 23.09 (community supported)
+
+  Don't see your version listed? Check the [releases page](https://github.com/jaredhendrickson13/pfsense-api/releases).
+  Older versions of this package may support older versions of pfSense.
 
   _This package is not supported on other architectures such as arm64 and aarch64. However, the package should still
   install and operate on these systems. Compatibility on unsupported systems is not guaranteed and is at your own risk._

--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ are made preventing the need for a reboot. All this results in the fastest, safe
 <details>
     <summary>Supported pfSense Versions</summary>
 
-  - pfSense CE 2.7.0 (amd64)
-  - pfSense Plus 23.01 (amd64)
-  - pfSense Plus 23.05 (amd64)
+  - pfSense CE 2.7.1 (amd64)
   - pfSense Plus 23.09 (community supported)
 
   _This package is not supported on other architectures such as arm64 and aarch64. However, the package should still

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
   "require": {
-    "firebase/php-jwt": "v6.9.*"
+    "firebase/php-jwt": "v6.10.*"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a11f1b5a7c7f1916c14f06b182e052cf",
+    "content-hash": "4f4c86b9227b9325c9ae20c18dbb69b1",
     "packages": [
         {
             "name": "firebase/php-jwt",
-            "version": "v6.9.0",
+            "version": "v6.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "f03270e63eaccf3019ef0f32849c497385774e11"
+                "reference": "a49db6f0a5033aef5143295342f1c95521b075ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/f03270e63eaccf3019ef0f32849c497385774e11",
-                "reference": "f03270e63eaccf3019ef0f32849c497385774e11",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/a49db6f0a5033aef5143295342f1c95521b075ff",
+                "reference": "a49db6f0a5033aef5143295342f1c95521b075ff",
                 "shasum": ""
             },
             "require": {
@@ -65,9 +65,9 @@
             ],
             "support": {
                 "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v6.9.0"
+                "source": "https://github.com/firebase/php-jwt/tree/v6.10.0"
             },
-            "time": "2023-10-05T00:24:42+00:00"
+            "time": "2023-12-01T16:26:39+00:00"
         }
     ],
     "packages-dev": [],
@@ -78,5 +78,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -6,9 +6,9 @@ Below are versions that are currently supported and will receive security update
 
 | Version | Supported          |
 |---------| ------------------ |
+| 1.7.x   | :white_check_mark: |
 | 1.6.x   | :white_check_mark: |
-| 1.5.x   | :white_check_mark: |
-| <=1.3.x | :x:                |
+| <=1.5.x | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallNATOutboundMappingCreate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallNATOutboundMappingCreate.inc
@@ -135,28 +135,29 @@ class APIFirewallNATOutboundMappingCreate extends APIModel {
         if (isset($this->initial_data['target'])) {
             # Require the target to be a valid IPv4 subnet, address, alias or empty string for iface address
             if (APITools\is_ip_subnet_or_alias($this->initial_data['target']) === "ipv4_subnet") {
-                $this->validated_data["target"] = "other-subnet";
-                $this->validated_data['targetip'] = explode("/", $this->initial_data["target"])[0];
-                $this->validated_data['targetip_subnet'] = explode("/", $this->initial_data["target"])[1];
-            } elseif (APITools\is_ip_subnet_or_alias($this->initial_data['target']) === "ipv4_addr") {
-                $this->validated_data["target"] = "other-subnet";
-                $this->validated_data["targetip"] = $this->initial_data['target'];
-                $this->validated_data['targetip_subnet'] = 32;
-            } elseif (APITools\is_ip_subnet_or_alias($this->initial_data['target']) === "alias") {
+                $this->validated_data['target'] = explode("/", $this->initial_data["target"])[0];
+                $this->validated_data['target_subnet'] = explode("/", $this->initial_data["target"])[1];
+            } 
+            elseif (APITools\is_ip_subnet_or_alias($this->initial_data['target']) === "ipv4_addr") {
+                $this->validated_data["target"] = $this->initial_data['target'];
+                $this->validated_data['target_subnet'] = 32;
+            } 
+            elseif (APITools\is_ip_subnet_or_alias($this->initial_data['target']) === "alias") {
                 # Only allow an alias if round-robin is chosen as the pool option
                 if (in_array($this->validated_data["poolopts"], ["round-robin", "round-robin sticky-address"])) {
                     $this->validated_data["target"] = $this->initial_data['target'];
                 } else {
                     $this->errors[] = APIResponse\get(4096);
                 }
-            } elseif ($this->initial_data["target"] === "") {
-                $this->validated_data["target"] = "";
-                $this->validated_data['targetip'] = "";
-                $this->validated_data['targetip_subnet'] = "";
-            } else {
+            } 
+            elseif ($this->initial_data["target"] === "" or $this->initial_data["target"] === $this->validated_data["interface"]."ip") {
+                $this->validated_data["target"] = $this->validated_data["interface"]."ip";
+            } 
+            else {
                 $this->errors[] = APIResponse\get(4095);
             }
-        } else {
+        } 
+        else {
             $this->errors[] = APIResponse\get(4094);
         }
     }

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallNATOutboundMappingUpdate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIFirewallNATOutboundMappingUpdate.inc
@@ -151,28 +151,25 @@ class APIFirewallNATOutboundMappingUpdate extends APIModel {
         if (isset($this->initial_data['target'])) {
             # Require the target to be a valid IPv4 subnet, address, alias or empty string for iface address
             if (APITools\is_ip_subnet_or_alias($this->initial_data['target']) === "ipv4_subnet") {
-                $this->validated_data["target"] = "other-subnet";
-                $this->validated_data['targetip'] = explode("/", $this->initial_data["target"])[0];
-                $this->validated_data['targetip_subnet'] = explode("/", $this->initial_data["target"])[1];
-            } elseif (APITools\is_ip_subnet_or_alias($this->initial_data['target']) === "ipv4_addr") {
-                $this->validated_data["target"] = "other-subnet";
-                $this->validated_data["targetip"] = $this->initial_data['target'];
-                $this->validated_data['targetip_subnet'] = 32;
-            } elseif (APITools\is_ip_subnet_or_alias($this->initial_data['target']) === "alias") {
-                # Only allow an alias if default or round-robin is chosen as the pool option
-                if (in_array($this->validated_data["poolopts"], ["", "round-robin", "round-robin sticky-address"])) {
-                    # Remove existing target IPs/subnets and add our alias as the target
-                    unset($this->validated_data["targetip"]);
-                    unset($this->validated_data["targetip_subnet"]);
+                $this->validated_data['target'] = explode("/", $this->initial_data["target"])[0];
+                $this->validated_data['target_subnet'] = explode("/", $this->initial_data["target"])[1];
+            }
+            elseif (APITools\is_ip_subnet_or_alias($this->initial_data['target']) === "ipv4_addr") {
+                $this->validated_data["target"] = $this->initial_data['target'];
+                $this->validated_data['target_subnet'] = 32;
+            }
+            elseif (APITools\is_ip_subnet_or_alias($this->initial_data['target']) === "alias") {
+                # Only allow an alias if round-robin is chosen as the pool option
+                if (in_array($this->validated_data["poolopts"], ["round-robin", "round-robin sticky-address"])) {
                     $this->validated_data["target"] = $this->initial_data['target'];
                 } else {
                     $this->errors[] = APIResponse\get(4096);
                 }
-            } elseif ($this->initial_data["target"] === "") {
-                $this->validated_data["target"] = "";
-                $this->validated_data['targetip'] = "";
-                $this->validated_data['targetip_subnet'] = "";
-            } else {
+            }
+            elseif ($this->initial_data["target"] === "" or $this->initial_data["target"] === $this->validated_data["interface"]."ip") {
+                $this->validated_data["target"] = $this->validated_data["interface"]."ip";
+            }
+            else {
                 $this->errors[] = APIResponse\get(4095);
             }
         }

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIInterfaceApplyCreate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIInterfaceApplyCreate.inc
@@ -91,12 +91,9 @@ class APIInterfaceApplyCreate extends APIModel {
                 else {
                     # Bring down the existing interface on the system if it exists
                     interface_bring_down($if_to_apply, true, $if_conf);
-
-                    # Restart DHCP services to remove DHCP server(s) on this interface
-                    if (APIModel::is_config_enabled("dhcpd/{$if_to_apply}") or APIModel::is_config_enabled("dhcpdv6/{$if_to_apply}")) {
-                        services_dhcpd_configure();
-                    }
                 }
+
+                restart_interface_services($if_to_apply, array_get_path($if_conf, 'ifcfg/ipaddrv6'));
 
                 # Interfaces with sub-interfaces (e.g. VLANs) need their MTU reconfigured if changed
                 if (interface_has_clones(get_real_interface($if_to_apply))) {
@@ -126,7 +123,6 @@ class APIInterfaceApplyCreate extends APIModel {
         }
 
         # Restart associated/dependent services
-        services_snmpd_configure();
         setup_gateways_monitor();
         clear_subsystem_dirty('interfaces');
         filter_configure();
@@ -137,14 +133,11 @@ class APIInterfaceApplyCreate extends APIModel {
             clear_subsystem_dirty('staticroutes');
         }
 
-        # Initialize syslog configuration and restart the syslog service
-        if (APIModel::is_config_enabled("syslog") and $if_to_apply == APIModel::get_config("syslog/sourceip")) {
-            system_syslogd_start();
-        }
-
         # After all is said and done, clear the interface subsystem status and remove the pending interface change file
         clear_subsystem_dirty('interfaces');
         @unlink($g['tmp_path']."/.interfaces.apply");
+
+        send_event("service reload packages");
     }
 
     # Apply interfaces asynchronously

--- a/tests/test_api_v1_interface.py
+++ b/tests/test_api_v1_interface.py
@@ -608,7 +608,7 @@ class APIE2ETestInterface(e2e_test_framework.APIE2ETest):
         {
             "name": "Disable interface",
             "resp_time": 5,
-            "post_test_callable": "is_if_disabled",
+            "post_test_callable": "is_if_disabled", 
             "req_data": {
                 "id": VLAN_IF,
                 "descr": "IF_DISABLED_TEST",
@@ -804,7 +804,7 @@ class APIE2ETestInterface(e2e_test_framework.APIE2ETest):
 
         # Loop through each line and check if em2.2 is now disabled
         for line in ifconfig_lines:
-            if line.startswith(f"{VLAN_IF}:") and "UP" in line:
+            if line.startswith(f"{VLAN_IF}:") and "<UP" in line:
                 raise AssertionError(f"Expected {VLAN_IF} to be disabled and not UP")
 
 

--- a/tests/test_api_v1_services_service_watchdog.py
+++ b/tests/test_api_v1_services_service_watchdog.py
@@ -34,7 +34,7 @@ class APIE2ETestServicesServiceWatchdog(e2e_test_framework.APIE2ETest):
             "name": "Install pfSense-pkg-Service_Watchdog so we can test further",
             "method": "POST",
             "uri": "/api/v1/system/package",
-            "resp_time": 30,
+            "resp_time": 60,
             "resp_data_empty": True,
             "req_data": {
                 "name": "pfSense-pkg-Service_Watchdog"

--- a/tests/test_api_v1_system_package.py
+++ b/tests/test_api_v1_system_package.py
@@ -17,7 +17,7 @@ class APIE2ETestSystemPackage(e2e_test_framework.APIE2ETest):
     post_tests = [
         {
             "name": "Check install of pfSense repo package",
-            "resp_time": 30,
+            "resp_time": 60,
             "resp_data_empty": True,
             "post_test_callable": "is_package_installed",
             "req_data": {
@@ -33,7 +33,7 @@ class APIE2ETestSystemPackage(e2e_test_framework.APIE2ETest):
             "name": "Check inability to install already installed package",
             "status": 400,
             "return": 1076,
-            "resp_time": 30,
+            "resp_time": 60,
             "req_data": {
                 "name": INSTALL_PKG_NAME
             }
@@ -52,7 +52,7 @@ class APIE2ETestSystemPackage(e2e_test_framework.APIE2ETest):
     delete_tests = [
             {
                 "name": "Test deletion of installed package",
-                "resp_time": 30,
+                "resp_time": 60,
                 "resp_data_empty": True,
                 "post_test_callable": "is_package_deleted",
                 "req_data": {


### PR DESCRIPTION
### Changes

- Uses new internal field names `target` and `target_subnet` for outbound NAT #422 
- Updates APIInterfaceApplyCreate to use new pfSense 2.7.1+ functions
- Bumps `php-jwt` to 6.10.0

_Note: pfSense 2.7.1+ contains some breaking changes that forces this release to deprecate support for pfSense 2.7.0._