### PR TITLE
fix: ensure APISystemAPIVersionRead::get_github_releases() always returns array

### DIFF
--- a/pfSense-pkg-API/files/etc/inc/api/models/APISystemAPIVersionRead.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APISystemAPIVersionRead.inc
@@ -83,7 +83,9 @@ class APISystemAPIVersionRead extends APIModel {
             $releases = ["last_updated" => time(), "releases" => $api_resp];
             file_put_contents($releases_file, json_encode($releases));
         }
-        return $releases;
+        
+        # Ensure releases is always an array
+        return (is_array($releases)) ? $releases : [];
     }
 
     public static function get_all_available_versions() {


### PR DESCRIPTION
### Fixes
- Adds a condition to return an empty array  in if the identified $releases is not an array in `APISystemAPIVersionRead::get_github_releases()`