### PR TITLE
fix: save sorted nat rules

### DIFF
--- a/pfSense-pkg-API/files/etc/inc/api/framework/APITools.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/framework/APITools.inc
@@ -352,6 +352,19 @@ function sort_nat_rules($top=false, $data=null, $field=null) {
             $sort_arr[] = $fre;
         }
     }
+
+
+    switch($field) {
+        case "onetoone":
+            config_set_path("nat/onetoone", $sort_arr);
+            break;
+        case "outbound":
+            config_set_path("nat/outbound/rule", $sort_arr);
+            break;
+        default:
+            config_set_path("nat/rule", $sort_arr);
+    }
+
     if (!empty($sort_arr)) {
         $acl = $sort_arr;
     } else {


### PR DESCRIPTION
In the current version, changing the order of nat rules has no effect. This patch fixes this bug.