### PR TITLE
v1.7.2

### DIFF
--- a/pfSense-pkg-API/files/etc/inc/api/models/APIServicesIPsecPhase2Create.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIServicesIPsecPhase2Create.inc
@@ -470,7 +470,7 @@ class APIServicesIPsecPhase2Create extends APIModel {
                 $this->errors[] = APIResponse\get(2252);
             }
         }
-        else {
+        elseif ($this->__is_hash_algo_required()) {
             $this->errors[] = APIResponse\get(2251);
         }
     }
@@ -576,5 +576,15 @@ class APIServicesIPsecPhase2Create extends APIModel {
         else {
             $this->validated_data["keepalive"] = "disabled";
         }
+    }
+
+    private function __is_hash_algo_required() {
+        foreach ($this->validated_data["encryption-algorithm-option"] as $enc_conf) {
+            if ($enc_conf["name"] === "aes") {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/pfSense-pkg-API/files/etc/inc/api/models/APIServicesIPsecPhase2Update.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APIServicesIPsecPhase2Update.inc
@@ -490,7 +490,7 @@ class APIServicesIPsecPhase2Update extends APIModel {
                 $this->errors[] = APIResponse\get(2252);
             }
         }
-        else {
+        elseif($this->__is_hash_algo_required()) {
             $this->errors[] = APIResponse\get(2251);
         }
     }
@@ -596,5 +596,15 @@ class APIServicesIPsecPhase2Update extends APIModel {
         elseif ($this->initial_data["keepalive"] === false) {
             $this->validated_data["keepalive"] = "disabled";
         }
+    }
+
+    private function __is_hash_algo_required() {
+        foreach ($this->validated_data["encryption-algorithm-option"] as $enc_conf) {
+            if ($enc_conf["name"] === "aes") {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/pfSense-pkg-API/files/etc/inc/api/models/APISystemAPIVersionRead.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APISystemAPIVersionRead.inc
@@ -83,7 +83,9 @@ class APISystemAPIVersionRead extends APIModel {
             $releases = ["last_updated" => time(), "releases" => $api_resp];
             file_put_contents($releases_file, json_encode($releases));
         }
-        return $releases;
+        
+        # Ensure releases is always an array
+        return (is_array($releases)) ? $releases : [];
     }
 
     public static function get_all_available_versions() {


### PR DESCRIPTION
- Fixes top sorting for NAT rules.
- Fixes an issue where IPsecPhase2 entries required a `hash-algorithm-option` when it was not actually required.