### PR TITLE
now when importing a certificate, it doesn't have the field 'type'

### DIFF
--- a/pfSense-pkg-API/files/etc/inc/api/models/APISystemCertificateCreate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APISystemCertificateCreate.inc
@@ -63,7 +63,6 @@ class APISystemCertificateCreate extends APIModel {
         if ($this->cert_method === "existing") {
             $this->__validate_crt();
             $this->__validate_prv();
-            $this->validated_data["type"] = "server";
         }
 
         # Validate 'internal' method fields


### PR DESCRIPTION
A solution to #540 