### PR TITLE
v2.2.1 Fixes & Features

### DIFF
--- a/docs/COMMON_CONTROL_PARAMETERS.md
+++ b/docs/COMMON_CONTROL_PARAMETERS.md
@@ -81,9 +81,9 @@ parameters you can use:
     you want to remove from. Then, make another request for the fields you want to replace.
 
 !!! Notes
-  - This parameter is only available for `PATCH` requests.
-  - This parameter is only applicable to array fields.
-  - If the submitted array values match the existing array values exactly, the API will not make any changes to that field to avoid removing all values unintentionally.
+    - This parameter is only available for `PATCH` requests.
+    - This parameter is only applicable to array fields.
+    - If the submitted array values match the existing array values exactly, the API will not make any changes to that field to avoid removing all values unintentionally.
 
 ## reverse
 

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Core/Model.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Core/Model.inc
@@ -936,13 +936,8 @@ class Model {
 
         # Loop through each of this Model's Fields and add its value to a serializable array
         foreach ($this->get_fields() as $field) {
-            # Skip adding this field if it's a write only field
-            if ($this->$field->write_only) {
-                continue;
-            }
-
-            # Skip adding this field if it is sensitive and sensitive fields are not exposed
-            if ($this->$field->sensitive and !$expose_sensitive_fields) {
+            # Skip adding this field if it's hidden
+            if ($this->is_field_hidden($field)) {
                 continue;
             }
 
@@ -1061,6 +1056,42 @@ class Model {
         }
 
         return null;
+    }
+
+    /**
+     * Determines if a given Model field should be hidden in responses.
+     * @param string $field The field name to check for sensitivity.
+     * @return bool Returns true if the field is sensitive, false if it is not.
+     */
+    private function is_field_hidden(string $field): bool {
+        # Variable
+        $pkg_config = RESTAPI\Models\RESTAPISettings::get_pkg_config();
+        $expose_sensitive_fields = $pkg_config['expose_sensitive_fields'] === 'enabled';
+        $overridden_sensitive_fields = explode(',', $pkg_config['override_sensitive_fields']);
+        $model_field_mapping = "{$this->get_class_shortname()}:$field";
+
+        # Field is hidden if it is 'write_only'
+        if ($this->$field->write_only) {
+            return true;
+        }
+
+        # Field is not hidden if the sensitive property is not set
+        if (!$this->$field->sensitive) {
+            return false;
+        }
+
+        # Field is not hidden if the 'expose_sensitive_fields' setting is enabled
+        if ($expose_sensitive_fields) {
+            return false;
+        }
+
+        # Field is not hidden if the field is in the 'override_sensitive_fields' setting
+        if (in_array($model_field_mapping, $overridden_sensitive_fields)) {
+            return false;
+        }
+
+        # Field is hidden if none of the above conditions are met
+        return true;
     }
 
     /**

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Dispatchers/RESTAPISettingsSyncDispatcher.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Dispatchers/RESTAPISettingsSyncDispatcher.inc
@@ -10,6 +10,7 @@ use RESTAPI\Models\RESTAPISettingsSync;
  */
 class RESTAPISettingsSyncDispatcher extends Dispatcher {
     public int $timeout = 60;
+    public int $max_queue = 1024;
 
     /**
      * Starts the REST API settings sync to HA peers.

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Forms/SystemRESTAPISettingsForm.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Forms/SystemRESTAPISettingsForm.inc
@@ -34,6 +34,7 @@ class SystemRESTAPISettingsForm extends Form {
                 'login_protection',
                 'log_successful_auth',
                 'expose_sensitive_fields',
+                'override_sensitive_fields',
             ],
         ],
         'Advanced Settings' => [

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/DHCPServerStaticMapping.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/DHCPServerStaticMapping.inc
@@ -41,6 +41,7 @@ class DHCPServerStaticMapping extends Model {
         $this->config_path = 'staticmap';
         $this->subsystem = 'dhcpd';
         $this->many = true;
+        $this->sort_by = ['ipaddr'];
 
         # Define model Fields
         $this->mac = new StringField(

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/IPsecPhase1.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/IPsecPhase1.inc
@@ -110,7 +110,7 @@ class IPsecPhase1 extends Model {
         );
         $this->myid_type = new StringField(
             required: true,
-            choices: ['myaddress', 'address', 'fqdn', 'user_fqdn', 'asn1dn', 'keyid tag', 'dyn_dns'],
+            choices: ['myaddress', 'address', 'fqdn', 'user_fqdn', 'asn1dn', 'keyid tag', 'dyn_dns', 'auto'],
             help_text: 'The identifier type used by the local end of the tunnel.',
         );
         $this->myid_data = new StringField(
@@ -121,7 +121,7 @@ class IPsecPhase1 extends Model {
         );
         $this->peerid_type = new StringField(
             required: true,
-            choices: ['any', 'peeraddress', 'address', 'fqdn', 'user_fqdn', 'asn1dn', 'keyid tag', 'dyn_dns'],
+            choices: ['any', 'peeraddress', 'address', 'fqdn', 'user_fqdn', 'asn1dn', 'keyid tag', 'dyn_dns', 'auto'],
             help_text: 'The identifier type used by the remote end of the tunnel.',
         );
         $this->peerid_data = new StringField(

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/RESTAPISettings.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/RESTAPISettings.inc
@@ -34,6 +34,7 @@ class RESTAPISettings extends Model {
     public BooleanField $allow_pre_releases;
     public BooleanField $hateoas;
     public BooleanField $expose_sensitive_fields;
+    public StringField $override_sensitive_fields;
     public InterfaceField $allowed_interfaces;
     public StringField $represent_interfaces_as;
     public StringField $auth_methods;
@@ -118,6 +119,15 @@ class RESTAPISettings extends Model {
             verbose_name: 'expose sensitive fields',
             help_text: 'Enables or disables exposing sensitive fields in API responses. When enabled, sensitive fields ' .
                 'such as passwords, private keys, and other sensitive data will be included in API responses.',
+        );
+        $this->override_sensitive_fields = new StringField(
+            default: [],
+            choices_callable: 'get_override_sensitive_fields_choices',
+            many: true,
+            conditions: ['expose_sensitive_fields' => false],
+            help_text: 'Specifies a list of fields (formatted as ModelName:FieldName) that should have their sensitive ' .
+                'attribute overridden. Fields selected here will not be considered sensitive and will be included in ' .
+                'API responses regardless of the `expose_sensitive_fields` setting.',
         );
         $this->allowed_interfaces = new InterfaceField(
             default: [],
@@ -210,6 +220,28 @@ class RESTAPISettings extends Model {
         foreach (get_classes_from_namespace(namespace: '\\RESTAPI\\Auth\\') as $auth_class) {
             $auth = new $auth_class();
             $choices[$auth->get_class_shortname()] = $auth->verbose_name;
+        }
+
+        return $choices;
+    }
+
+    /**
+     * Obtains the choices for the `override_sensitive_fields` field. This will dynamically populate a choice for each
+     * Model and Field in the \RESTAPI\Models namespace.
+     */
+    public function get_override_sensitive_fields_choices(): array {
+        # Variables
+        $choices = [];
+
+        # Format choices so they include the class's verbose name as the choice's verbose name
+        foreach (get_classes_from_namespace(namespace: '\\RESTAPI\\Models\\') as $model_class) {
+            $model = new $model_class();
+            foreach ($model->get_fields() as $field) {
+                if ($model->$field->sensitive) {
+                    $choices[$model->get_class_shortname() . ':' . $field] =
+                        $model->get_class_shortname() . ':' . $field;
+                }
+            }
         }
 
         return $choices;

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsAPISettingsTestCase.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsAPISettingsTestCase.inc
@@ -567,4 +567,26 @@ class APIModelsAPISettingsTestCase extends TestCase {
         $user = new User(id: 0);
         $this->assert_is_empty($user->to_representation()['password']);
     }
+
+    /**
+     * Checks that the `override_sensitive_fields` field successfully overrides specified sensitive fields in the Model's
+     * representation.
+     */
+    public function test_override_sensitive_fields(): void {
+        # Ignore the sensitive flag for the User model's password field
+        $api_settings = new RESTAPISettings(override_sensitive_fields: ['User:password']);
+        $api_settings->update();
+
+        # Ensure we can now read the password field in the User model's representation
+        $user = new User(id: 0);
+        $this->assert_is_not_empty($user->to_representation()['password']);
+
+        # Reset the override_sensitive_fields setting
+        $api_settings = new RESTAPISettings(override_sensitive_fields: []);
+        $api_settings->update();
+
+        # Ensure we can no longer read the password
+        $user = new User(id: 0);
+        $this->assert_is_empty($user->to_representation()['password']);
+    }
 }

--- a/pfSense-pkg-RESTAPI/files/usr/local/share/pfSense-pkg-RESTAPI/info.xml
+++ b/pfSense-pkg-RESTAPI/files/usr/local/share/pfSense-pkg-RESTAPI/info.xml
@@ -17,6 +17,7 @@
             <log_successful_auth>disabled</log_successful_auth>
             <hateoas>disabled</hateoas>
             <expose_sensitive_fields>disabled</expose_sensitive_fields>
+            <override_sensitive_fields></override_sensitive_fields>
             <allow_pre_releases>disabled</allow_pre_releases>
             <allowed_interfaces></allowed_interfaces>
             <represent_interfaces_as>id</represent_interfaces_as>

--- a/tools/make_package.py
+++ b/tools/make_package.py
@@ -39,7 +39,7 @@ class MakePackage:
         self.port_revision = self.args.tag.split("_", maxsplit=1)[1]
 
         # Allow package to build on systems that no longer have upstream ports support
-        os.environ['ALLOW_UNSUPPORTED_SYSTEM'] = 'yes'
+        os.environ["ALLOW_UNSUPPORTED_SYSTEM"] = "yes"
 
         # Run tasks for build mode
         if self.args.host:

--- a/tools/make_package.py
+++ b/tools/make_package.py
@@ -38,6 +38,9 @@ class MakePackage:
         self.port_version = self.args.tag.split("_")[0]
         self.port_revision = self.args.tag.split("_", maxsplit=1)[1]
 
+        # Allow package to build on systems that no longer have upstream ports support
+        os.environ['ALLOW_UNSUPPORTED_SYSTEM'] = 'yes'
+
         # Run tasks for build mode
         if self.args.host:
             self.build_on_remote_host()


### PR DESCRIPTION
### New

- Adds the `override_sensitive_fields` REST API setting to allow admins to override field's `sensitive` property. #582 
- Add `auto` as a choice for the IPsecPhase1 `myid_type` and `peerid_type` fields. #584

### Fixes

- Increases the maximum number of queued API sync processes to 1024.
- Sort DHCPServerStaticMappings by `ipaddr` #583
- Fixes an issue that prevented the package from being built on FreeBSD versions that no longer have upstream port tree support.