### PR TITLE
v2.2.2 Fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Build pfSense-pkg-RESTAPI on FreeBSD
         run: |
           /usr/bin/ssh -o StrictHostKeyChecking=no ${{ matrix.FREEBSD_VERSION }}.jaredhendrickson.com 'sudo pkill ntpd || true && sudo ntpdate pool.ntp.org || true'
-          /usr/local/bin/python3 tools/make_package.py --host ${{ matrix.FREEBSD_VERSION }}.jaredhendrickson.com --branch ${{ github.sha }} --tag ${{ github.ref_name }} --filename pfSense-${{ matrix.PFSENSE_VERSION }}-pkg-RESTAPI.pkg
+          /usr/local/bin/python3 tools/make_package.py --host ${{ matrix.FREEBSD_VERSION }}.jaredhendrickson.com --branch ${{ github.sha }} --tag ${{ github.ref_name }} --filename pfSense-${{ matrix.PFSENSE_VERSION }}-pkg-RESTAPI.pkg --notests
 
       - name: Teardown FreeBSD build VM
         if: "${{ always() }}"

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/WireGuardPeerAllowedIP.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/WireGuardPeerAllowedIP.inc
@@ -35,7 +35,7 @@ class WireGuardPeerAllowedIP extends Model {
         );
         $this->mask = new IntegerField(
             required: true,
-            minimum: 1,
+            minimum: 0,
             maximum: 128,
             help_text: 'The subnet mask for this peer IP.',
         );

--- a/tools/make_package.py
+++ b/tools/make_package.py
@@ -69,6 +69,10 @@ class MakePackage:
         }
         excluded_files = ["pkg-deinstall.in", "pkg-install.in", "etc", "usr"]
 
+        # Remove tests from the package if the user has specified to do so
+        if self.args.notests:
+            os.system(f"rm -rf {files_dir.joinpath('usr/local/pkg/RESTAPI/Tests')}")
+
         # Set Jijna2 environment and variables
         j2_env = jinja2.Environment(
             autoescape=jinja2.select_autoescape([]),
@@ -131,6 +135,7 @@ class MakePackage:
         """Runs the build on a remote host using SSH."""
         # Automate the process to pull, install dependencies, build and retrieve the package on a remote host
         includes_dir = f"~/build/{REPO_NAME}/{PKG_NAME}/files/usr/local/pkg/RESTAPI/.resources/vendor/"
+        notests = "--notests" if self.args.notests else ""
         build_cmds = [
             "mkdir -p ~/build/",
             f"rm -rf ~/build/{REPO_NAME}",
@@ -138,7 +143,7 @@ class MakePackage:
             f"git -C ~/build/{REPO_NAME} checkout " + self.args.branch,
             f"composer install --working-dir ~/build/{REPO_NAME}",
             f"cp -r ~/build/{REPO_NAME}/vendor/* {includes_dir}",
-            f"python3 ~/build/{REPO_NAME}/tools/make_package.py --tag {self.args.tag}",
+            f"python3 ~/build/{REPO_NAME}/tools/make_package.py --tag {self.args.tag} {notests}",
         ]
 
         # Run each command and exit on bad status if failure
@@ -213,6 +218,11 @@ class MakePackage:
             required=False,
             help="filename to use for the built package file.",
         )
+        parser.add_argument(
+            "--notests",
+            dest="notests",
+            action="store_true",
+            help="Exclude tests from the package build.",)
         self.args = parser.parse_args()
 
 

--- a/tools/make_package.py
+++ b/tools/make_package.py
@@ -222,7 +222,8 @@ class MakePackage:
             "--notests",
             dest="notests",
             action="store_true",
-            help="Exclude tests from the package build.",)
+            help="Exclude tests from the package build.",
+        )
         self.args = parser.parse_args()
 
 


### PR DESCRIPTION
### Fixes

- Reduces the minimum requirement for WireGuardPeerAllowedIP `mask` field from 1 to 0. #595 
- Prevents a warning that would occur when `pfSense-repoc` is called with the package installed. #588 

### Changes

- Tests have been removed from full release builds of the package. #588 