### PR TITLE
added openvpn server port

### DIFF
--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/OpenVPNClient.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/OpenVPNClient.inc
@@ -135,7 +135,7 @@ class OpenVPNClient extends Model {
             required: true,
             allow_alias: false,
             allow_range: false,
-            allow_null: true,
+            allow_null: false,
             help_text: 'The port used by the server to receive client connections.',
         );
         $this->local_port = new PortField(

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/OpenVPNClient.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/OpenVPNClient.inc
@@ -131,7 +131,7 @@ class OpenVPNClient extends Model {
             validators: [new IPAddressValidator(allow_ipv4: true, allow_ipv6: true, allow_fqdn: true)],
             help_text: 'The IP address or hostname of the OpenVPN server this client will connect to.',
         );
-        $this->local_port = new PortField(
+        $this->server_port = new PortField(
             required: true,
             allow_alias: false,
             allow_range: false,

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/OpenVPNClient.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/OpenVPNClient.inc
@@ -32,6 +32,7 @@ class OpenVPNClient extends Model {
     public StringField $protocol;
     public InterfaceField $interface;
     public StringField $server_addr;
+    public StringField $server_port;
     public PortField $local_port;
     public StringField $proxy_addr;
     public PortField $proxy_port;
@@ -129,6 +130,13 @@ class OpenVPNClient extends Model {
             required: true,
             validators: [new IPAddressValidator(allow_ipv4: true, allow_ipv6: true, allow_fqdn: true)],
             help_text: 'The IP address or hostname of the OpenVPN server this client will connect to.',
+        );
+        $this->local_port = new PortField(
+            required: true,
+            allow_alias: false,
+            allow_range: false,
+            allow_null: true,
+            help_text: 'The port used by the server to receive client connections.',
         );
         $this->local_port = new PortField(
             default: null,

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsOpenVPNClientTestCase.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsOpenVPNClientTestCase.inc
@@ -42,6 +42,7 @@ class APIModelsOpenVPNClientTestCase extends TestCase {
             'protocol' => 'UDP4',
             'interface' => 'wan',
             'server_addr' => 'example.com',
+            'server_port' => '1194',
             'tls' => $this->tls_key,
             'tls_type' => 'auth',
             'dh_length' => '2048',


### PR DESCRIPTION
<img width="775" alt="image" src="https://github.com/user-attachments/assets/977bad1d-e601-4124-9c71-8eddb230fe03" />
<img width="561" alt="image" src="https://github.com/user-attachments/assets/f7187764-81cd-41e8-924c-50e0d128002a" />

In the latest version of openvpn-2.6.8_1
there is a mandatory server_port field. But this field is missing in the API. This makes it impossible to work with OpenVPN VPN clients.