### PR TITLE
Fixed adding a gateway with a dynamic address to Firewall Rules. Added tag field to Firewall Rules

### DIFF
--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/FirewallRule.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/FirewallRule.inc
@@ -174,6 +174,7 @@ class FirewallRule extends Model {
         );
         $this->tag = new StringField(
             default: '',
+            allow_empty: true,
             help_text: 'A packet matching this rule can be marked and this mark used to match on other NAT/filter rules. It is called ',
         );
         $this->statetype = new StringField(

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/FirewallRule.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/FirewallRule.inc
@@ -35,6 +35,7 @@ class FirewallRule extends Model {
     public StringField $descr;
     public BooleanField $disabled;
     public BooleanField $log;
+    public StringField $tag;
     public StringField $statetype;
     public BooleanField $tcp_flags_any;
     public StringField $tcp_flags_out_of;
@@ -171,6 +172,10 @@ class FirewallRule extends Model {
             default: false,
             help_text: 'Enable or disable logging of traffic that matches this rule.',
         );
+        $this->tag = new StringField(
+            default: '',
+            help_text: 'A packet matching this rule can be marked and this mark used to match on other NAT/filter rules. It is called ',
+        );
         $this->statetype = new StringField(
             default: 'keep state',
             choices: ['keep state', 'sloppy state', 'synproxy state', 'none'],
@@ -200,7 +205,7 @@ class FirewallRule extends Model {
             help_text: 'The TCP flags that must be set for this rule to match.',
         );
         $this->gateway = new ForeignModelField(
-            model_name: ['RoutingGateway', 'RoutingGatewayGroup'],
+            model_name: ['RoutingGateway', 'RoutingGatewayGroup', 'RoutingGatewayStatus'],
             model_field: 'name',
             default: null,
             allow_null: true,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/dc59f04a-7277-49c7-bb38-f41a7d7675cf)
![image](https://github.com/user-attachments/assets/8e987139-67b4-4bc7-86fb-b950b1fef6c1)
![image](https://github.com/user-attachments/assets/275f85be-3ab6-455e-930c-6d8f648d63d9)

As far as I understood, in the firewall rules in the api, you can select only a gateway with a static ip address, but for firewall rules you can also connect a gateway with a dynamic address (for example, OpenVPN).

The tag field has also been added.