### PR TITLE
fix: correct internal callable name in IPsecChildSAStatus

### DIFF
--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/IPsecChildSAStatus.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/IPsecChildSAStatus.inc
@@ -40,7 +40,7 @@ class IPsecChildSAStatus extends Model {
 
     public function __construct(mixed $id = null, mixed $parent_id = null, mixed $data = [], ...$options) {
         # Set model attributes
-        $this->internal_callable = 'get_ipsec_child SA_statuses';
+        $this->internal_callable = 'get_ipsec_sa_statuses';
         $this->parent_model_class = 'IPsecSAStatus';
         $this->verbose_name = 'IPsec Child SA Status';
         $this->many = true;

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APICoreModelTestCase.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APICoreModelTestCase.inc
@@ -1248,4 +1248,23 @@ class APICoreModelTestCase extends RESTAPI\Core\TestCase {
         $dhcp_server->staticmap->value = [];
         $dhcp_server->update(apply: true);
     }
+
+    /**
+     * Checks that all Model classes with an internal_callable assigned have an existing callable assigned.
+     */
+    public function test_model_internal_callables_exist(): void {
+        # Loop through all Model classes
+        foreach (Model::get_all_model_classes() as $model_class) {
+            # Create a new instance of the Model class
+            $model_obj = new $model_class(skip_init: true);
+
+            # Skip models that don't have an internal callable assigned
+            if (!$model_obj->internal_callable) {
+                continue;
+            }
+
+            # Ensure the internal callable exists
+            $this->assert_is_true(method_exists($model_obj, $model_obj->internal_callable));
+        }
+    }
 }


### PR DESCRIPTION
- Fixes a bad function reference that resulted in a 500 error on /api/v2/status/ipsec/child_sa