### PR TITLE
v2.4.0 Fixes & Features

### DIFF
--- a/.github/workflows/schedule_weekly.yml
+++ b/.github/workflows/schedule_weekly.yml
@@ -23,4 +23,4 @@ jobs:
             This pull request has been automatically marked as stale because it has had no recent activity in the last ${{ env.DAYS_BEFORE_STALE }} days.
           days-before-stale: ${{ env.DAYS_BEFORE_STALE }}
           days-before-close: 0
-          exempt-issue-labels: "feature request,enhancement"
+          exempt-issue-labels: "feature request,enhancement,bug"

--- a/.github/workflows/schedule_weekly.yml
+++ b/.github/workflows/schedule_weekly.yml
@@ -3,7 +3,7 @@ name: Weekly Schedule
 on:
   workflow_dispatch: # Enable manual triggering
   schedule:
-    - cron: '0 18 * * 1'
+    - cron: "0 18 * * 1"
 
 permissions:
   issues: write
@@ -23,4 +23,4 @@ jobs:
             This pull request has been automatically marked as stale because it has had no recent activity in the last ${{ env.DAYS_BEFORE_STALE }} days.
           days-before-stale: ${{ env.DAYS_BEFORE_STALE }}
           days-before-close: 0
-          exempt-issue-labels: 'feature request,enhancement'
+          exempt-issue-labels: "feature request,enhancement"

--- a/.github/workflows/schedule_weekly.yml
+++ b/.github/workflows/schedule_weekly.yml
@@ -1,0 +1,26 @@
+name: Weekly Schedule
+
+on:
+  workflow_dispatch: # Enable manual triggering
+  schedule:
+    - cron: '0 18 * * 1'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    env:
+      DAYS_BEFORE_STALE: 60
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has had no recent activity in the last ${{ env.DAYS_BEFORE_STALE }} days.
+          stale-pr-message: |
+            This pull request has been automatically marked as stale because it has had no recent activity in the last ${{ env.DAYS_BEFORE_STALE }} days.
+          days-before-stale: ${{ env.DAYS_BEFORE_STALE }}
+          days-before-close: 0
+          exempt-issue-labels: 'feature request,enhancement'

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ![Docs](https://img.shields.io/website?url=https%3A%2F%2Fpfrest.org&label=Documentation)
 
 The pfSense REST API package is an unofficial, open-source REST and GraphQL API for pfSense CE and pfSense Plus
-firewalls.It is designed to be light-weight, fast, and easy to use. This guide will help you get started with the REST
+firewalls. It is designed to be light-weight, fast, and easy to use. This guide will help you get started with the REST
 API package and provide you with the information you need to configure and use the package effectively.
 
 ## Key Features

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Install on pfSense Plus:
 pkg-static -C /dev/null add https://github.com/jaredhendrickson13/pfsense-api/releases/latest/download/pfSense-24.03-pkg-RESTAPI.pkg
 ```
 
+## Support for pfSense Plus 24.11
+
+Working on supporting in https://github.com/jaredhendrickson13/pfsense-api/discussions/610
+
 > [!IMPORTANT]
 > You may need to customize the installation command to reference the package built for your pfSense version. Check
 > the [releases page](https://github.com/jaredhendrickson13/pfsense-api/releases) to find the package built for

--- a/composer.lock
+++ b/composer.lock
@@ -71,16 +71,16 @@
         },
         {
             "name": "webonyx/graphql-php",
-            "version": "v15.18.0",
+            "version": "v15.18.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webonyx/graphql-php.git",
-                "reference": "bd620384497500ecfdf44313dd98ecb95fb88975"
+                "reference": "a167afab66d8aa74b7f552759c0bbd906afb4134"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/bd620384497500ecfdf44313dd98ecb95fb88975",
-                "reference": "bd620384497500ecfdf44313dd98ecb95fb88975",
+                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/a167afab66d8aa74b7f552759c0bbd906afb4134",
+                "reference": "a167afab66d8aa74b7f552759c0bbd906afb4134",
                 "shasum": ""
             },
             "require": {
@@ -98,8 +98,8 @@
                 "nyholm/psr7": "^1.5",
                 "phpbench/phpbench": "^1.2",
                 "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "1.12.7",
-                "phpstan/phpstan-phpunit": "1.4.0",
+                "phpstan/phpstan": "1.12.10",
+                "phpstan/phpstan-phpunit": "1.4.1",
                 "phpstan/phpstan-strict-rules": "1.6.1",
                 "phpunit/phpunit": "^9.5 || ^10.5.21 || ^11",
                 "psr/http-message": "^1 || ^2",
@@ -133,7 +133,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webonyx/graphql-php/issues",
-                "source": "https://github.com/webonyx/graphql-php/tree/v15.18.0"
+                "source": "https://github.com/webonyx/graphql-php/tree/v15.18.1"
             },
             "funding": [
                 {
@@ -141,7 +141,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-10-31T12:10:43+00:00"
+            "time": "2024-11-13T16:21:54+00:00"
         }
     ],
     "packages-dev": [],

--- a/docs/INSTALL_AND_CONFIG.md
+++ b/docs/INSTALL_AND_CONFIG.md
@@ -70,16 +70,60 @@ pfsense-restapi delete
 
 ## Updating the package
 
+Before updating the package, it is recommended to enable the REST API's 'Keep Backup' setting to ensure that your
+REST API configurations, keys and access lists are not lost during the update process. It is also highly recommended to
+read and understand both the release change notes on GitHub and the [versioning policy](#versioning-policy) to ensure
+you do not unintentionally introduce breaking changes to your environment.
+
+!!! Tip
+    While the package is updating, the REST API may be unavailable for a short period of time. Updates typically complete
+    within a minute, but may vary depending on network environment and conditions. It is recommended to
+    schedule updates during off-peak hours to minimize impact to your integrations. In the event that the update fails,
+    or takes an excessive amount of time, it is recommended to uninstall and reinstall the package.
+
+### From the pfSense webConfigurator
+
+You can easily update or revert the package version from the pfSense webConfigurator by navigating to 'System' -> 
+'REST API' -> 'Updates' and select the desired version. Click 'Save' to apply the desired version. 
+
+### From the API
+
+You can update or revert the package to a specified version by sending a request to the [PATCH 
+/api/v2/system/restapi/version](https://pfrest.org/api-docs/#/SYSTEM/patchSystemRESTAPIVersionEndpoint) endpoint.
+Simply set the `install_version` field to the desired version and send the request.
+
+### From the command line
+
 You can update the package to latest version available to your pfSense version by running the following command:
 
 ```bash
 pfsense-restapi update
 ```
 
-## Reverting the package to a specific version
-
-If you need to revert or upgrade the package to a specific version, you can do so by running the following command:
+If you need to revert or upgrade the package to a _specific_ version, you can do so by running the following command:
 
 ```bash
 pfsense-restapi revert <version>
 ```
+
+## Versioning policy
+
+The REST API package loosely follows [Semantic Versioning](https://semver.org/). The versioning policy is as follows:
+
+- Major version changes (e.g. 1.x.x to 2.x.x) may include major breaking changes and are not guaranteed to be backwards
+  compatible. Major changes will often include significant changes to the framework, endpoints, schemas, and/or behavior.
+- Minor version changes (e.g. 2.0.x to 2.1.x) may include new features, bug fixes, and/or minor breaking changes. Breaking
+  changes will be isolated to specific endpoints and will be documented in the release notes.
+- Patch version changes (e.g. 2.0.0 to 2.0.1) will only include bug fixes and very small enhancements. Patches will
+  never contain breaking changes or significant new features that could impact existing functionality.
+
+### Pre-release versions
+
+Pre-release versions are occasionally made available to the public to allow for testing of new features and fixes. 
+Pre-releases will be notated as such on GitHub and are not considered as release candidates within the REST API package's
+update features by default. You may opt-in to pre-release updates by enabling the 'Allow Pre-releases' setting in the
+REST API settings.
+
+!!! Warning
+    Pre-release versions may contain breaking changes, bugs, and/or incomplete features. It is recommended to only use
+    pre-release versions in testing environments and never in production.

--- a/docs/INSTALL_AND_CONFIG.md
+++ b/docs/INSTALL_AND_CONFIG.md
@@ -47,7 +47,9 @@ pkg-static -C /dev/null add https://github.com/jaredhendrickson13/pfsense-api/re
       the [releases page](https://github.com/jaredhendrickson13/pfsense-api/releases) to find the package built for
       your version of pfSense.
     - When updating pfSense, **you must reinstall this package afterward** as pfSense removes unofficial packages during
-      system updates and has no way to automatically reinstall them.
+      system updates and has no way to automatically reinstall them. 
+    - If you're looking for a method of programmatically installing the package without SSH, check out 
+      [pfsense-vshell](https://github.com/jaredhendrickson13/pfsense-vshell)!
 
 ## Configuring the package
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,21 +1,29 @@
 # Security Policy
 
+Security is a top priority for this project. The REST API package is designed to be secure and provide granular controls
+to help admins implement a multi-layered security approach to API access. This document outlines the security policy 
+for the project and provides information on how to report a security vulnerability.
+
 ## Supported Versions
 
-Below are versions that are currently supported and will receive security updates when available.
-
-| Version | Supported          |
-|---------| ------------------ |
-| 2.2.x   | :white_check_mark: |
-| 1.7.x   | :white_check_mark: |
-| <=1.6.x | :x:                |
+Currently, there are two supported versions of the package: the v2 package (pfSense-pkg-RESTAPI) and the legacy v1 
+package (pfSense-pkg-API). The v2 package is the latest version of the package and is actively developed and fully 
+maintained. The legacy v1 package is no longer actively developed and is only receiving compatibility fixes and critical
+security updates when necessary. It is highly recommended to regularly update to the latest version of the package to 
+ensure you are receiving important bug fixes and security updates.
 
 ## Reporting a Vulnerability
 
-Should you discover a vulnerability in the pfSense-API code, please report the issue in one of the following ways:
+Should you discover a vulnerability in the codebase, please report the issue using the order of preference below:
 
 1. A pull request with code that fixes the discovered vulnerability
 2. A private email to either the project owner or the respective code owner
 3. As a last resort, you may open a public issue on the repository
 
-Please note this is an independent and open-source project and no bug bounty or reward can be granted.
+Please do not disclose the details of the vulnerability publicly until it has been addressed by the maintainers. 
+The maintainers will work to address the vulnerability as quickly as possible and will provide updates on the issue 
+as they become available.
+
+!!! Notice
+    This is an open-source project and is developed and maintained by members of the pfSense community. No bug bounty
+    can be offered for reported vulnerabilities.

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,9 +40,9 @@ opening a pull request.
 - <a href="https://github.com/jaredhendrickson13"><img src="https://github.com/jaredhendrickson13.png" alt="Jared Hendrickson" title="Jared Hendrickson" width="30" height="30"/> Jared Hendrickson</img></a> - github@jaredhendrickson.com
 
 !!! Important
-    Unless your inquiry is regarding a security vulnerability or other sensitive matter, please do not contact the
-    maintainers directly. Instead, please [open an issue](https://github.com/jaredhendrickson13/pfsense-api/issues/new/choose)
-    to report a bug or request a feature. For general questions or help requests, please [open a discussion](https://github.com/jaredhendrickson13/pfsense-api/discussions/new/choose).
+    Unless your inquiry is regarding a [security vulnerability](SECURITY.md) or other sensitive matter, please do not 
+    contact the maintainers directly. Instead, please [open an issue](https://github.com/jaredhendrickson13/pfsense-api/issues/new/choose) to report a bug or request a feature. For 
+    general questions or help requests, please [open a discussion](https://github.com/jaredhendrickson13/pfsense-api/discussions/new/choose).
 
 ## Disclaimers
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
   - Advanced Topics:
       - Introduction: ADVANCED_TOPICS_INTRO.md
       - Contributing & Development: CONTRIBUTING.md
+      - Security Policy: SECURITY.md
       - Building Custom Authentication: BUILDING_CUSTOM_AUTH_CLASSES.md
       - Building Custom Query Filters: BUILDING_CUSTOM_QUERY_FILTER_CLASSES.md
       - Building Custom Models: BUILDING_CUSTOM_MODEL_CLASSES.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "devDependencies": {
         "@prettier/plugin-php": "^0.22.2",
-        "@stoplight/spectral-cli": "^6.13.1"
+        "@stoplight/spectral-cli": "^6.14.2"
       }
     },
     "node_modules/@asyncapi/specs": {
@@ -238,19 +238,19 @@
       }
     },
     "node_modules/@stoplight/spectral-cli": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.13.1.tgz",
-      "integrity": "sha512-v6ipX4w6wRhtbOotwdPL7RrEkP0m1OwHTIyqzVrAPi932F/zkee24jmf1CHNrTynonmfGoU6/XpeqUHtQdKDFw==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.14.2.tgz",
+      "integrity": "sha512-yn49Tkin/Zzjwt39CbQvj3NZVolvXrjO3OLNn+Yd+LhQE5C96QNsULuE4q98e7+WRcLu4gK+Z0l5CxYNtsoPtw==",
       "dev": true,
       "dependencies": {
         "@stoplight/json": "~3.21.0",
         "@stoplight/path": "1.3.2",
-        "@stoplight/spectral-core": "^1.18.3",
-        "@stoplight/spectral-formatters": "^1.3.0",
-        "@stoplight/spectral-parsers": "^1.0.3",
+        "@stoplight/spectral-core": "^1.19.4",
+        "@stoplight/spectral-formatters": "^1.4.1",
+        "@stoplight/spectral-parsers": "^1.0.4",
         "@stoplight/spectral-ref-resolver": "^1.0.4",
-        "@stoplight/spectral-ruleset-bundler": "^1.5.4",
-        "@stoplight/spectral-ruleset-migrator": "^1.9.6",
+        "@stoplight/spectral-ruleset-bundler": "^1.6.0",
+        "@stoplight/spectral-ruleset-migrator": "^1.11.0",
         "@stoplight/spectral-rulesets": ">=1",
         "@stoplight/spectral-runtime": "^1.1.2",
         "@stoplight/types": "^13.6.0",
@@ -258,22 +258,22 @@
         "fast-glob": "~3.2.12",
         "hpagent": "~1.2.0",
         "lodash": "~4.17.21",
-        "pony-cause": "^1.0.0",
-        "stacktracey": "^2.1.7",
-        "tslib": "^2.3.0",
+        "pony-cause": "^1.1.1",
+        "stacktracey": "^2.1.8",
+        "tslib": "^2.8.1",
         "yargs": "~17.7.2"
       },
       "bin": {
         "spectral": "dist/index.js"
       },
       "engines": {
-        "node": "^12.20 || >= 14.13"
+        "node": "^16.20 || ^18.18 || >= 20.17"
       }
     },
     "node_modules/@stoplight/spectral-core": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.19.2.tgz",
-      "integrity": "sha512-Yx1j7d0VGEbsOCimPgl+L8w7ZuuOaxqGvXSUXgm9weoGR5idLQjPaTuHLdfdziR1gjqQdVTCEk/dN0cFfUKhow==",
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.19.4.tgz",
+      "integrity": "sha512-8hnZXfssTlV99SKo8J8BwMt5LsiBFHkCh0V3P7j8IPcCNl//bpG92U4TpYy7AwmUms/zCLX7sxNQC6AZ+bkfzg==",
       "dev": true,
       "dependencies": {
         "@stoplight/better-ajv-errors": "1.0.3",
@@ -281,7 +281,7 @@
         "@stoplight/path": "1.3.2",
         "@stoplight/spectral-parsers": "^1.0.0",
         "@stoplight/spectral-ref-resolver": "^1.0.4",
-        "@stoplight/spectral-runtime": "^1.0.0",
+        "@stoplight/spectral-runtime": "^1.1.2",
         "@stoplight/types": "~13.6.0",
         "@types/es-aggregate-error": "^1.0.2",
         "@types/json-schema": "^7.0.11",
@@ -289,14 +289,14 @@
         "ajv-errors": "~3.0.0",
         "ajv-formats": "~2.1.0",
         "es-aggregate-error": "^1.0.7",
-        "jsonpath-plus": "10.1.0",
+        "jsonpath-plus": "10.2.0",
         "lodash": "~4.17.21",
         "lodash.topath": "^4.5.2",
         "minimatch": "3.1.2",
         "nimma": "0.2.3",
-        "pony-cause": "^1.0.0",
+        "pony-cause": "^1.1.1",
         "simple-eval": "1.0.1",
-        "tslib": "^2.3.0"
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": "^16.20 || ^18.18 || >= 20.17"
@@ -316,62 +316,64 @@
       }
     },
     "node_modules/@stoplight/spectral-formats": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-formats/-/spectral-formats-1.7.0.tgz",
-      "integrity": "sha512-vJ1vIkA2s96fdJp0d3AJBGuPAW3sj8yMamyzR+dquEFO6ZAoYBo/BVsKKQskYzZi/nwljlRqUmGVmcf2PncIaA==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-formats/-/spectral-formats-1.8.2.tgz",
+      "integrity": "sha512-c06HB+rOKfe7tuxg0IdKDEA5XnjL2vrn/m/OVIIxtINtBzphZrOgtRn7epQ5bQF5SWp84Ue7UJWaGgDwVngMFw==",
       "dev": true,
       "dependencies": {
         "@stoplight/json": "^3.17.0",
-        "@stoplight/spectral-core": "^1.8.0",
+        "@stoplight/spectral-core": "^1.19.2",
         "@types/json-schema": "^7.0.7",
-        "tslib": "^2.3.1"
+        "tslib": "^2.8.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": "^16.20 || ^18.18 || >= 20.17"
       }
     },
     "node_modules/@stoplight/spectral-formatters": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-formatters/-/spectral-formatters-1.3.0.tgz",
-      "integrity": "sha512-ryuMwlzbPUuyn7ybSEbFYsljYmvTaTyD51wyCQs4ROzgfm3Yo5QDD0IsiJUzUpKK/Ml61ZX8ebgiPiRFEJtBpg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-formatters/-/spectral-formatters-1.4.3.tgz",
+      "integrity": "sha512-03Nc6nhjMO9aHhJPgBH4zDwMPklKLWEMtvx+PMmzfStCndMjJkf8ki7O/55u3myZ1TwxBzln9z9tXPLSL3KKhw==",
       "dev": true,
       "dependencies": {
         "@stoplight/path": "^1.3.2",
-        "@stoplight/spectral-core": "^1.15.1",
-        "@stoplight/spectral-runtime": "^1.1.0",
+        "@stoplight/spectral-core": "^1.19.4",
+        "@stoplight/spectral-runtime": "^1.1.2",
         "@stoplight/types": "^13.15.0",
+        "@types/markdown-escape": "^1.1.3",
         "chalk": "4.1.2",
         "cliui": "7.0.4",
         "lodash": "^4.17.21",
+        "markdown-escape": "^2.0.0",
         "node-sarif-builder": "^2.0.3",
         "strip-ansi": "6.0",
         "text-table": "^0.2.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.8.1"
       },
       "engines": {
-        "node": "^12.20 || >=14.13"
+        "node": "^16.20 || ^18.18 || >= 20.17"
       }
     },
     "node_modules/@stoplight/spectral-functions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-functions/-/spectral-functions-1.9.0.tgz",
-      "integrity": "sha512-T+xl93ji8bpus4wUsTq8Qr2DSu2X9PO727rbxW61tTCG0s17CbsXOLYI+Ezjg5P6aaQlgXszGX8khtc57xk8Yw==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-functions/-/spectral-functions-1.9.3.tgz",
+      "integrity": "sha512-jy4mguk0Ddz0Vr76PHervOZeyXTUW650zVfNT2Vt9Ji3SqtTVziHjq913CBVEGFS+IQw1McUXuHVLM6YKVZ6fQ==",
       "dev": true,
       "dependencies": {
         "@stoplight/better-ajv-errors": "1.0.3",
         "@stoplight/json": "^3.17.1",
-        "@stoplight/spectral-core": "^1.7.0",
-        "@stoplight/spectral-formats": "^1.7.0",
-        "@stoplight/spectral-runtime": "^1.1.0",
+        "@stoplight/spectral-core": "^1.19.4",
+        "@stoplight/spectral-formats": "^1.8.1",
+        "@stoplight/spectral-runtime": "^1.1.2",
         "ajv": "^8.17.1",
         "ajv-draft-04": "~1.0.0",
         "ajv-errors": "~3.0.0",
         "ajv-formats": "~2.1.0",
         "lodash": "~4.17.21",
-        "tslib": "^2.3.0"
+        "tslib": "^2.8.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": "^16.20 || ^18.18 || >= 20.17"
       }
     },
     "node_modules/@stoplight/spectral-parsers": {
@@ -446,28 +448,28 @@
       }
     },
     "node_modules/@stoplight/spectral-ruleset-migrator": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-ruleset-migrator/-/spectral-ruleset-migrator-1.10.0.tgz",
-      "integrity": "sha512-nDfkVfYeWWv0UvILC4TWZSnRqQ4rHgeOJO1/lHQ7XHeG5iONanQ639B1aK6ZS6vuUc8gwuyQsrPF67b4sHIyYw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-ruleset-migrator/-/spectral-ruleset-migrator-1.11.1.tgz",
+      "integrity": "sha512-z2A1Ual3bU7zLDxYqdHaxYgyirb7TVDaWXc9ONEBAo5W1isio0EHV59ujAUEOUHCLcY5ubd0eYeqgSjqPIQe8w==",
       "dev": true,
       "dependencies": {
         "@stoplight/json": "~3.21.0",
         "@stoplight/ordered-object-literal": "~1.0.4",
         "@stoplight/path": "1.3.2",
-        "@stoplight/spectral-functions": "^1.0.0",
-        "@stoplight/spectral-runtime": "^1.1.0",
+        "@stoplight/spectral-functions": "^1.9.1",
+        "@stoplight/spectral-runtime": "^1.1.2",
         "@stoplight/types": "^13.6.0",
         "@stoplight/yaml": "~4.2.3",
         "@types/node": "*",
         "ajv": "^8.17.1",
         "ast-types": "0.14.2",
-        "astring": "^1.7.5",
+        "astring": "^1.9.0",
         "reserved": "0.1.2",
-        "tslib": "^2.3.1",
+        "tslib": "^2.8.1",
         "validate-npm-package-name": "3.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": "^16.20 || ^18.18 || >= 20.17"
       }
     },
     "node_modules/@stoplight/spectral-ruleset-migrator/node_modules/@stoplight/yaml": {
@@ -614,6 +616,12 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
+    },
+    "node_modules/@types/markdown-escape": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/markdown-escape/-/markdown-escape-1.1.3.tgz",
+      "integrity": "sha512-JIc1+s3y5ujKnt/+N+wq6s/QdL2qZ11fP79MijrVXsAAnzSxCbT2j/3prHRouJdZ2yFLN3vkP0HytfnoCczjOw==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -789,9 +797,9 @@
       }
     },
     "node_modules/astring": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/astring/-/astring-1.8.6.tgz",
-      "integrity": "sha512-ISvCdHdlTDlH5IpxQJIex7BWBywFWgjJSVdwst+/iQCoEYnyOaQ95+X1JGshuBjGp6nxKUy1jMgE3zPqN7fQdg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
       "dev": true,
       "bin": {
         "astring": "bin/astring"
@@ -1889,14 +1897,14 @@
       }
     },
     "node_modules/jsonpath-plus": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.1.0.tgz",
-      "integrity": "sha512-gHfV1IYqH8uJHYVTs8BJX1XKy2/rR93+f8QQi0xhx95aCiXn1ettYAd5T+7FU6wfqyDoX/wy0pm/fL3jOKJ9Lg==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.2.0.tgz",
+      "integrity": "sha512-T9V+8iNYKFL2n2rF+w02LBOT2JjDnTjioaNFrxRy0Bv1y/hNsqR/EBK7Ojy2ythRHwmz2cRIls+9JitQGZC/sw==",
       "dev": true,
       "dependencies": {
-        "@jsep-plugin/assignment": "^1.2.1",
-        "@jsep-plugin/regex": "^1.0.3",
-        "jsep": "^1.3.9"
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
       },
       "bin": {
         "jsonpath": "bin/jsonpath-cli.js",
@@ -1950,6 +1958,12 @@
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
       }
+    },
+    "node_modules/markdown-escape": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-escape/-/markdown-escape-2.0.0.tgz",
+      "integrity": "sha512-Trz4v0+XWlwy68LJIyw3bLbsJiC8XAbRCKF9DbEtZjyndKOGVx6n+wNB0VfoRmY2LKboQLeniap3xrb6LGSJ8A==",
+      "dev": true
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -2538,9 +2552,9 @@
       "dev": true
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true
     },
     "node_modules/typed-array-buffer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,10 +18,22 @@
         "@types/json-schema": "^7.0.11"
       }
     },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
     "node_modules/@jsep-plugin/regex": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.3.tgz",
-      "integrity": "sha512-XfZgry4DwEZvSFtS/6Y+R48D7qJYJK6R9/yJFyUFHCIUMEEHuJ4X95TDgJp5QkmzfLYvapMPzskV5HpIDrREug==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
       "dev": true,
       "engines": {
         "node": ">= 10.16.0"
@@ -31,9 +43,9 @@
       }
     },
     "node_modules/@jsep-plugin/ternary": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@jsep-plugin/ternary/-/ternary-1.1.3.tgz",
-      "integrity": "sha512-qtLGzCNzPVJ3kdH6/zoLWDPjauHIKiLSBAR71Wa0+PWvGA8wODUQvRgxtpUA5YqAYL3CQ8S4qXhd/9WuWTZirg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/ternary/-/ternary-1.1.4.tgz",
+      "integrity": "sha512-ck5wiqIbqdMX6WRQztBL7ASDty9YLgJ3sSAK5ZpBzXeySvFGCzIvM6UiAI4hTZ22fEcYQVV/zhUbNscggW+Ukg==",
       "dev": true,
       "engines": {
         "node": ">= 10.16.0"
@@ -259,35 +271,35 @@
       }
     },
     "node_modules/@stoplight/spectral-core": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.18.3.tgz",
-      "integrity": "sha512-YY8x7X2SWJIhGTLPol+eFiQpWPz0D0mJdkK2i4A0QJG68KkNhypP6+JBC7/Kz3XWjqr0L/RqAd+N5cQLPOKZGQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.19.2.tgz",
+      "integrity": "sha512-Yx1j7d0VGEbsOCimPgl+L8w7ZuuOaxqGvXSUXgm9weoGR5idLQjPaTuHLdfdziR1gjqQdVTCEk/dN0cFfUKhow==",
       "dev": true,
       "dependencies": {
         "@stoplight/better-ajv-errors": "1.0.3",
         "@stoplight/json": "~3.21.0",
         "@stoplight/path": "1.3.2",
         "@stoplight/spectral-parsers": "^1.0.0",
-        "@stoplight/spectral-ref-resolver": "^1.0.0",
+        "@stoplight/spectral-ref-resolver": "^1.0.4",
         "@stoplight/spectral-runtime": "^1.0.0",
         "@stoplight/types": "~13.6.0",
         "@types/es-aggregate-error": "^1.0.2",
         "@types/json-schema": "^7.0.11",
-        "ajv": "^8.6.0",
+        "ajv": "^8.17.1",
         "ajv-errors": "~3.0.0",
         "ajv-formats": "~2.1.0",
         "es-aggregate-error": "^1.0.7",
-        "jsonpath-plus": "7.1.0",
+        "jsonpath-plus": "10.1.0",
         "lodash": "~4.17.21",
         "lodash.topath": "^4.5.2",
         "minimatch": "3.1.2",
-        "nimma": "0.2.2",
+        "nimma": "0.2.3",
         "pony-cause": "^1.0.0",
-        "simple-eval": "1.0.0",
+        "simple-eval": "1.0.1",
         "tslib": "^2.3.0"
       },
       "engines": {
-        "node": "^12.20 || >= 14.13"
+        "node": "^16.20 || ^18.18 || >= 20.17"
       }
     },
     "node_modules/@stoplight/spectral-core/node_modules/@stoplight/types": {
@@ -1844,9 +1856,9 @@
       "dev": true
     },
     "node_modules/jsep": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.3.8.tgz",
-      "integrity": "sha512-qofGylTGgYj9gZFsHuyWAN4jr35eJ66qJCK4eKDnldohuUoQFbU3iZn2zjvEbd9wOAhP9Wx5DsAAduTyE1PSWQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "dev": true,
       "engines": {
         "node": ">= 10.16.0"
@@ -1877,12 +1889,21 @@
       }
     },
     "node_modules/jsonpath-plus": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.1.0.tgz",
-      "integrity": "sha512-gTaNRsPWO/K2KY6MrqaUFClF9kmuM6MFH5Dhg1VYDODgFbByw1yb7xu3hrViE/sz+dGOeMWgCzwUwQtAnCTE9g==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.1.0.tgz",
+      "integrity": "sha512-gHfV1IYqH8uJHYVTs8BJX1XKy2/rR93+f8QQi0xhx95aCiXn1ettYAd5T+7FU6wfqyDoX/wy0pm/fL3jOKJ9Lg==",
       "dev": true,
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.2.1",
+        "@jsep-plugin/regex": "^1.0.3",
+        "jsep": "^1.3.9"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/jsonpointer": {
@@ -1965,9 +1986,9 @@
       }
     },
     "node_modules/nimma": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/nimma/-/nimma-0.2.2.tgz",
-      "integrity": "sha512-V52MLl7BU+tH2Np9tDrIXK8bql3MVUadnMIl/0/oZSGC9keuro0O9UUv9QKp0aMvtN8HRew4G7byY7H4eWsxaQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/nimma/-/nimma-0.2.3.tgz",
+      "integrity": "sha512-1ZOI8J+1PKKGceo/5CT5GfQOG6H8I2BencSK06YarZ2wXwH37BSSUWldqJmMJYA5JfqDqffxDXynt6f11AyKcA==",
       "dev": true,
       "dependencies": {
         "@jsep-plugin/regex": "^1.0.1",
@@ -1979,18 +2000,8 @@
         "node": "^12.20 || >=14.13"
       },
       "optionalDependencies": {
-        "jsonpath-plus": "^6.0.1",
+        "jsonpath-plus": "^6.0.1 || ^10.1.0",
         "lodash.topath": "^4.5.2"
-      }
-    },
-    "node_modules/nimma/node_modules/jsonpath-plus": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-6.0.1.tgz",
-      "integrity": "sha512-EvGovdvau6FyLexFH2OeXfIITlgIbgZoAZe3usiySeaIDm5QS+A10DKNpaPBBqqRSZr2HN6HVNXxtwUAr2apEw==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/node-fetch": {
@@ -2366,12 +2377,12 @@
       }
     },
     "node_modules/simple-eval": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/simple-eval/-/simple-eval-1.0.0.tgz",
-      "integrity": "sha512-kpKJR+bqTscgC0xuAl2xHN6bB12lHjC2DCUfqjAx19bQyO3R2EVLOurm3H9AUltv/uFVcSCVNc6faegR+8NYLw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-eval/-/simple-eval-1.0.1.tgz",
+      "integrity": "sha512-LH7FpTAkeD+y5xQC4fzS+tFtaNlvt3Ib1zKzvhjv/Y+cioV4zIuw4IZr2yhRLu67CWL7FR9/6KXKnjRoZTvGGQ==",
       "dev": true,
       "dependencies": {
-        "jsep": "^1.1.2"
+        "jsep": "^1.3.6"
       },
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
     "@prettier/plugin-php": "^0.22.2",
-    "@stoplight/spectral-cli": "^6.13.1"
+    "@stoplight/spectral-cli": "^6.14.2"
   }
 }

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Core/Endpoint.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Core/Endpoint.inc
@@ -1147,8 +1147,10 @@ class Endpoint {
      * Creates a new object for the assigned Model using the data submitted in a POST request.
      */
     protected function post(): Model|ModelSet {
-        # POST request cannot include an ID, strip the ID if present
-        unset($this->request_data['id']);
+        # POST requests cannot include an ID unless auto_create_id is off
+        if ($this->model->auto_create_id) {
+            unset($this->request_data['id']);
+        }
 
         # Construct the model from representation using the client's request data
         $this->model->from_representation(data: $this->request_data);

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Core/Form.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Core/Form.inc
@@ -132,7 +132,7 @@ class Form {
 
         # Gather information about the authenticated user
         $client = new Auth();
-        $client->username = $_SESSION['Username'] ?: DEFAULT_CLIENT_USERNAME;
+        $client->username = $_SESSION['Username'];
 
         # Obtain the `id` from URL parameters
         $this->id = is_numeric($_GET['id']) ? intval($_GET['id']) : null;
@@ -403,7 +403,9 @@ class Form {
         }
 
         try {
-            (new $this->model(id: $id))->delete();
+            $model_to_delete = new $this->model(id: $id);
+            $model_to_delete->client = $this->model->client;
+            $model_to_delete->delete();
             $this->print_success_banner("Deleted {$this->model->verbose_name} with ID $id.");
         } catch (Response $resp_error) {
             $error_message = $resp_error->getMessage();

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Core/Model.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Core/Model.inc
@@ -90,6 +90,15 @@ class Model {
     public string $id_type = 'integer';
 
     /**
+     * @var bool $auto_create_id
+     * Enables or disables automatic creation of an ID for this Model object when the `create()` method is called. If
+     * set to `true`, the ID will be automatically generated. If set to `false`, an ID must be provided before the
+     * `create()` method is called. This applies exclusively to Models with $many enabled and is usually only
+     * relevant to Model classes that use an internal callable method.
+     */
+    public bool $auto_create_id = true;
+
+    /**
      * @var mixed $parent_id
      * For Models acting as children to a different Model class, this property will contain the ID of the parent model
      * object. If a $parent_model_class is defined, this value MUST be specified during object construction.
@@ -2036,7 +2045,7 @@ class Model {
      */
     final public function create(bool $apply = false): Model {
         # Ensure all object Fields and validations succeed for proceeding.
-        if ($this->validate(create_id: true)) {
+        if ($this->validate(requires_id: !$this->auto_create_id, create_id: $this->auto_create_id)) {
             # Check if creating this object would put the total number of objects over the $many_maximum
             $this->check_many_maximum();
 

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Endpoints/ServicesDHCPRelayEndpoint.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Endpoints/ServicesDHCPRelayEndpoint.inc
@@ -1,0 +1,22 @@
+<?php
+
+namespace RESTAPI\Endpoints;
+
+require_once 'RESTAPI/autoloader.inc';
+
+use RESTAPI\Core\Endpoint;
+
+/**
+ * Defines an Endpoint for interacting with the DHCPRelay Model object at /api/v2/services/dhcp_relay.
+ */
+class ServicesDHCPRelayEndpoint extends Endpoint {
+    public function __construct() {
+        # Set Endpoint attributes
+        $this->url = '/api/v2/services/dhcp_relay';
+        $this->model_name = 'DHCPRelay';
+        $this->request_method_options = ['GET', 'PATCH'];
+
+        # Construct the parent Endpoint object
+        parent::__construct();
+    }
+}

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/BINDZone.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/BINDZone.inc
@@ -35,10 +35,10 @@ class BINDZone extends Model {
     public StringField $nameserver;
     public StringField $mail;
     public IntegerField $serial;
-    public IntegerField $refresh;
-    public IntegerField $retry;
-    public IntegerField $expire;
-    public IntegerField $minimum;
+    public StringField $refresh;
+    public StringField $retry;
+    public StringField $expire;
+    public StringField $minimum;
     public BooleanField $enable_updatepolicy;
     public StringField $updatepolicy;
     public ForeignModelField $allowupdate;
@@ -161,30 +161,34 @@ class BINDZone extends Model {
             conditions: ['type' => ['master', 'redirect']],
             help_text: 'The SOA serial number for this zone.',
         );
-        $this->refresh = new IntegerField(
+        $this->refresh = new StringField(
             default: null,
             allow_null: true,
             conditions: ['type' => ['master', 'redirect']],
-            help_text: 'The SOA refresh interval (in seconds) for this zone.',
+            help_text: 'The SOA refresh interval for this zone. TTL-style time-unit suffixes are ' .
+                'supported (e.g. 1h, 1d, 1w), otherwise time in seconds is assumed.',
         );
-        $this->retry = new IntegerField(
+        $this->retry = new StringField(
             default: null,
             allow_null: true,
             conditions: ['type' => ['master', 'redirect']],
-            help_text: 'The SOA retry interval (in seconds) for this zone.',
+            help_text: 'The SOA retry interval for this zone. TTL-style time-unit suffixes are ' .
+                'supported (e.g. 1h, 1d, 1w), otherwise time in seconds is assumed.',
         );
-        $this->expire = new IntegerField(
+        $this->expire = new StringField(
             default: null,
             allow_null: true,
             conditions: ['type' => ['master', 'redirect']],
-            help_text: 'The SOA expiry interval (in seconds) for this zone.',
+            help_text: 'The SOA expiry interval for this zone. TTL-style time-unit suffixes are ' .
+                'supported (e.g. 1h, 1d, 1w), otherwise time in seconds is assumed.',
         );
-        $this->minimum = new IntegerField(
+        $this->minimum = new StringField(
             default: null,
             allow_null: true,
             conditions: ['type' => ['master', 'redirect']],
             help_text: 'The SOA minimum TTL interval (in seconds) for this zone. This is also referred to as the ' .
-                'negative TTL.',
+                'negative TTL. TTL-style time-unit suffixes are supported (e.g. 1h, 1d, 1w), otherwise time in ' .
+                'seconds is assumed.',
         );
         $this->enable_updatepolicy = new BooleanField(
             default: false,

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/DHCPRelay.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/DHCPRelay.inc
@@ -1,0 +1,109 @@
+<?php
+
+namespace RESTAPI\Models;
+
+use RESTAPI\Core\Model;
+use RESTAPI\Fields\BooleanField;
+use RESTAPI\Fields\ForeignModelField;
+use RESTAPI\Fields\InterfaceField;
+use RESTAPI\Fields\StringField;
+use RESTAPI\Responses\ConflictError;
+use RESTAPI\Validators\IPAddressValidator;
+
+/**
+ * Defines a Model for interacting with the DHCP relay configuration.
+ */
+class DHCPRelay extends Model {
+    public BooleanField $enable;
+    public InterfaceField $interface;
+    public BooleanField $agentoption;
+    public ForeignModelField $carpstatusvip;
+    public StringField $server;
+
+    public function __construct(mixed $id = null, mixed $parent_id = null, mixed $data = [], mixed ...$options) {
+        # Set model attributes
+        $this->config_path = 'dhrelay';
+        $this->many = false;
+        $this->always_apply = true;
+
+        # Set model fields
+        $this->enable = new BooleanField(default: false, help_text: 'Enables or disables the DHCP relay.');
+        $this->interface = new InterfaceField(
+            default: [],
+            many: true,
+            help_text: 'The downstream interfaces to listen on for DHCP requests.',
+        );
+        $this->agentoption = new BooleanField(
+            default: false,
+            help_text: 'Enables or disables appending the circuit ID (interface number) and the agent ID to the ' .
+                'DHCP request.',
+        );
+        $this->carpstatusvip = new ForeignModelField(
+            model_name: 'VirtualIP',
+            model_field: 'uniqid',
+            allowed_keywords: ['none'],
+            default: 'none',
+            help_text: 'DHCP Relay will be stopped when the chosen VIP is in BACKUP status, and started ' .
+                'in MASTER status.',
+        );
+        $this->server = new StringField(
+            required: true,
+            many: true,
+            many_minimum: 1,
+            validators: [new IPAddressValidator(allow_ipv6: false)],
+            help_text: 'The IPv4 addresses of the DHCP server to relay requests to.',
+        );
+
+        parent::__construct($id, $parent_id, $data, ...$options);
+    }
+
+    /**
+     * Provide extra validation to the 'enable' field.
+     * @param bool $enable The value to be validated.
+     * @return bool The validated value.
+     * @throws ConflictError If the DHCP relay is being enabled but a DHCP Server is running.
+     */
+    public function validate_enable(bool $enable): bool {
+        if ($enable and DHCPServer::query(enable: true)->exists()) {
+            throw new ConflictError(
+                message: 'DHCP Relay cannot be enabled while DHCP Server is enabled on any interface.',
+                response_id: 'DHCP_RELAY_CANNOT_BE_ENABLED_WHILE_DHCP_SERVER_IS_ENABLED',
+            );
+        }
+
+        return $enable;
+    }
+
+    /**
+     * Override the default 'to_internal()' method to ensure the carpstatusvip field is prefixed with '_vip'.
+     */
+    public function to_internal(): array|string {
+        $internal_data = parent::to_internal();
+
+        if ($this->carpstatusvip->value !== 'none') {
+            $internal_data['carpstatusvip'] = "_vip{$internal_data['carpstatusvip']}";
+        }
+
+        return $internal_data;
+    }
+
+    /**
+     * Add custom logic for when the 'carpstatusvip' field is being set from its internal value. This is used to
+     * remove the _vip prefix from the value so the framework can locate it's related VirtualIP model.
+     */
+    public function from_internal_carpstatusvip(string $value): string {
+        if (str_starts_with($value, '_vip')) {
+            return substr($value, 4);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Apply changes to the DHCP relay
+     */
+    public function apply(): void {
+        services_dhcrelay_configure();
+        filter_configure();
+    }
+}

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/DHCPRelay.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/DHCPRelay.inc
@@ -22,7 +22,7 @@ class DHCPRelay extends Model {
 
     public function __construct(mixed $id = null, mixed $parent_id = null, mixed $data = [], mixed ...$options) {
         # Set model attributes
-        $this->config_path = 'dhrelay';
+        $this->config_path = 'dhcrelay';
         $this->many = false;
         $this->always_apply = true;
 

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/DHCPServer.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/DHCPServer.inc
@@ -316,14 +316,13 @@ class DHCPServer extends Model {
         }
 
         # Do not allow the DHCP server to be enabled if this interface is already running a DHCP relay
-        # TODO: Replace this with a Model query when the DHCPRelay Model is developed
-        foreach ($this->get_config('dhcrelay', []) as $dhcp_relay) {
-            if ($this->id === $dhcp_relay['interface']) {
-                throw new ValidationError(
-                    message: 'DHCP server cannot be enabled because a DHCP relay is already running.',
-                    response_id: 'DHCP_SERVER_CANNOT_BE_ENABLED_WITH_DHCP_RELAY',
-                );
-            }
+        $dhcp_relay = new DHCPRelay();
+        if (in_array($this->interface->value, $dhcp_relay->interface->value)) {
+            throw new ValidationError(
+                message: "DHCP server cannot be enabled while a DHCP Relay is enabled on " .
+                    "interface {$this->interface->value}.",
+                response_id: 'DHCP_SERVER_CANNOT_BE_ENABLED_WITH_DHCP_RELAY',
+            );
         }
 
         return $enable;

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/DHCPServer.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/DHCPServer.inc
@@ -315,12 +315,11 @@ class DHCPServer extends Model {
             );
         }
 
-        # Do not allow the DHCP server to be enabled if this interface is already running a DHCP relay
+        # Do not allow the DHCP server to be enabled if any interface is running a DHCP relay
         $dhcp_relay = new DHCPRelay();
-        if (in_array($this->interface->value, $dhcp_relay->interface->value)) {
+        if ($dhcp_relay->enable->value) {
             throw new ValidationError(
-                message: 'DHCP server cannot be enabled while a DHCP Relay is enabled on ' .
-                    "interface {$this->interface->value}.",
+                message: 'DHCP server cannot be enabled while the DHCP Relay is enabled.',
                 response_id: 'DHCP_SERVER_CANNOT_BE_ENABLED_WITH_DHCP_RELAY',
             );
         }

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/DHCPServer.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/DHCPServer.inc
@@ -319,7 +319,7 @@ class DHCPServer extends Model {
         $dhcp_relay = new DHCPRelay();
         if (in_array($this->interface->value, $dhcp_relay->interface->value)) {
             throw new ValidationError(
-                message: "DHCP server cannot be enabled while a DHCP Relay is enabled on " .
+                message: 'DHCP server cannot be enabled while a DHCP Relay is enabled on ' .
                     "interface {$this->interface->value}.",
                 response_id: 'DHCP_SERVER_CANNOT_BE_ENABLED_WITH_DHCP_RELAY',
             );

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyBackend.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyBackend.inc
@@ -4,6 +4,7 @@ namespace RESTAPI\Models;
 
 use RESTAPI\Core\Model;
 use RESTAPI\Dispatchers\HAProxyApplyDispatcher;
+use RESTAPI\Fields\Base64Field;
 use RESTAPI\Fields\BooleanField;
 use RESTAPI\Fields\IntegerField;
 use RESTAPI\Fields\InterfaceField;
@@ -72,7 +73,7 @@ class HAProxyBackend extends Model {
     public NestedModelField $errorfiles;
     public BooleanField $cookie_attribute_secure;
     public StringField $advanced;
-    public StringField $advanced_backend;
+    public Base64Field $advanced_backend;
     public BooleanField $transparent_clientip;
     public InterfaceField $transparent_interface;
 
@@ -439,7 +440,7 @@ class HAProxyBackend extends Model {
             allow_empty: true,
             help_text: 'The per server pass thru to apply to each server line.',
         );
-        $this->advanced_backend = new StringField(
+        $this->advanced_backend = new Base64Field(
             default: '',
             allow_empty: true,
             help_text: 'The backend pass thru to apply to the backend section.',

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/OpenVPNClient.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/OpenVPNClient.inc
@@ -32,6 +32,7 @@ class OpenVPNClient extends Model {
     public StringField $protocol;
     public InterfaceField $interface;
     public StringField $server_addr;
+    public StringField $server_port;
     public PortField $local_port;
     public StringField $proxy_addr;
     public PortField $proxy_port;
@@ -129,6 +130,13 @@ class OpenVPNClient extends Model {
             required: true,
             validators: [new IPAddressValidator(allow_ipv4: true, allow_ipv6: true, allow_fqdn: true)],
             help_text: 'The IP address or hostname of the OpenVPN server this client will connect to.',
+        );
+        $this->server_port = new PortField(
+            required: true,
+            allow_alias: false,
+            allow_range: false,
+            allow_null: false,
+            help_text: 'The port used by the server to receive client connections.',
         );
         $this->local_port = new PortField(
             default: null,

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/OpenVPNClient.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/OpenVPNClient.inc
@@ -32,7 +32,7 @@ class OpenVPNClient extends Model {
     public StringField $protocol;
     public InterfaceField $interface;
     public StringField $server_addr;
-    public StringField $server_port;
+    public PortField $server_port;
     public PortField $local_port;
     public StringField $proxy_addr;
     public PortField $proxy_port;

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/Service.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/Service.inc
@@ -20,20 +20,17 @@ class Service extends Model {
     public function __construct(mixed $id = null, mixed $parent_id = null, mixed $data = [], mixed ...$options) {
         # Set Model attributes
         $this->internal_callable = 'get_services';
+        $this->auto_create_id = false; // We don't create services with create(), we just control existing ones
         $this->many = true;
 
         # Set Model Fields
-        $this->name = new StringField(
-            required: true,
-            choices_callable: 'get_service_name_choices',
-            help_text: 'The internal name of the service.',
-        );
         $this->action = new StringField(
             required: true,
             choices: ['start', 'stop', 'restart'],
             write_only: true,
             help_text: 'The action to perform against this service.',
         );
+        $this->name = new StringField(read_only: true, help_text: 'The internal name of the service.');
         $this->description = new StringField(read_only: true, help_text: 'The full descriptive name of the service.');
         $this->enabled = new BooleanField(
             read_only: true,
@@ -57,59 +54,52 @@ class Service extends Model {
      * @return array An array of available pfSense services and their current statuses.
      */
     public static function get_services(): array {
-        # Variables
-        $services = get_services();
-
-        # Loop through each service and set the proper values
-        foreach ($services as $id => $service) {
-            # Ensure the $enabled and $status values are always present
-            $services[$id]['enabled'] = is_service_enabled($service['name']);
-            $services[$id]['status'] = is_service_running($service['name']);
-        }
-
-        return $services;
-    }
-
-    /**
-     * Obtains all internal service choices for the `name` field.
-     * @return array An array of available service names.
-     */
-    public function get_service_name_choices(): array {
-        $choices = [];
-        foreach ($this->get_services() as $service) {
-            $choices[] = $service['name'];
-        }
-        return $choices;
-    }
-
-    /**
-     * Gets the representation ID for a given service name.
-     * @param string $name The internal service to obtain the ID for.
-     * @return int The representation ID of the service with this name.
-     */
-    public function get_id_by_name(string $name): int {
-        return $this->query(['name' => $name])->first()->id;
+        return get_services();
     }
 
     /**
      * Starts or stops a specified service.
      */
-    public function _create() {
+    public function _create(): void {
+        # Obtain the extras for this service. Provides additional info required for some services to be controlled.
+        $extras = $this->_format_extra_data($this->get_services()[$this->id]);
+
         # Trigger the requested service action
         switch ($this->action->value) {
             case 'start':
-                service_control_start(name: $this->name->value, extras: []);
+                service_control_start(name: $this->name->value, extras: $extras);
                 break;
             case 'stop':
-                service_control_stop(name: $this->name->value, extras: []);
+                service_control_stop(name: $this->name->value, extras: $extras);
                 break;
             case 'restart':
-                service_control_restart(name: $this->name->value, extras: []);
+                service_control_restart(name: $this->name->value, extras: $extras);
                 break;
         }
 
-        # Populate the current status of the service with this name so this object is up-to-date.
-        $this->id = $this->get_id_by_name($this->name->value);
+        # Recheck the service status after the action has been performed to ensure the correct status is returned
         $this->from_internal();
+    }
+
+    /**
+     * Formats the 'extra' service data required for some services to be restarted to the weird format pfSense
+     * sometimes expects. In the webConfigurator, this process is obfuscated by AJAX calls and JavaScript so there
+     * is no direct function to format this data. This function is a workaround to provide the correct data format.
+     *
+     * @param array $service The service data to format.
+     * @return array The formatted service data suitable for the service control functions 'extras' parameter.
+     */
+    public function _format_extra_data(array $service): array {
+        # Format OpenVPN service extra data for service control
+        if ($service['name'] === 'openvpn') {
+            # 'mode' changes to 'vpnmode'
+            $service['vpnmode'] = $service['mode'];
+            unset($service['mode']);
+
+            # 'vpnid' changes to just 'id'
+            $service['id'] = $service['vpnid'];
+        }
+
+        return $service;
     }
 }

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Schemas/OpenAPISchema.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Schemas/OpenAPISchema.inc
@@ -184,7 +184,7 @@ class OpenAPISchema extends Schema {
                     }
 
                     # For non `many` Endpoints with `many` Models, add the ID to the schema and make it required
-                    if (!$endpoint->many and $model->many and $request_method !== 'post') {
+                    if (!$endpoint->many and $model->many and ($request_method !== 'post' or !$model->auto_create_id)) {
                         $schema = [
                             'schema' => [
                                 'allOf' => [

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsBINDZoneTestCase.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsBINDZoneTestCase.inc
@@ -49,10 +49,10 @@ class APIModelsBINDZoneTestCase extends TestCase {
             nameserver: 'ns1.example.com',
             mail: 'admin.example.com',
             serial: 123456,
-            refresh: 3605,
-            retry: 605,
-            expire: 86405,
-            minimum: 2605,
+            refresh: '3605',
+            retry: '605',
+            expire: '86405',
+            minimum: '2605',
             records: [
                 ['name' => 'a.example.com.', 'type' => 'A', 'rdata' => '4.3.2.1'],
                 ['name' => 'mx.example.com.', 'type' => 'MX', 'rdata' => 'mail.example.com.', 'priority' => 5],
@@ -92,10 +92,10 @@ class APIModelsBINDZoneTestCase extends TestCase {
         $zone->nameserver->value = 'ns2.example.com';
         $zone->mail->value = 'admin2.example.com';
         $zone->serial->value = 654321;
-        $zone->refresh->value = 3606;
-        $zone->retry->value = 606;
-        $zone->expire->value = 86406;
-        $zone->minimum->value = 2606;
+        $zone->refresh->value = '3606';
+        $zone->retry->value = '606';
+        $zone->expire->value = '86406';
+        $zone->minimum->value = '2606';
         $zone->records->value = [
             ['name' => 'a2.example.com.', 'type' => 'A', 'rdata' => '5.5.5.5'],
             ['name' => 'mx2.example.com.', 'type' => 'MX', 'rdata' => 'mail2.example.com.', 'priority' => 15],

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsDHCPRelayTestCase.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsDHCPRelayTestCase.inc
@@ -81,7 +81,7 @@ class APIModelsDHCPRelayTestCase extends TestCase {
         $this->disable_dhcp_servers(apply: true);
 
         # Ensure the DHCPRelay is enabled
-        $dhcp_relay = new DHCPRelay(enable: true, interface: ["lan"], server: ['1.2.3.4']);
+        $dhcp_relay = new DHCPRelay(enable: true, interface: ['lan'], server: ['1.2.3.4']);
         $dhcp_relay->update();
 
         # Ensure the DHCP relay service is running with the correct arguments

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsDHCPRelayTestCase.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsDHCPRelayTestCase.inc
@@ -32,7 +32,7 @@ class APIModelsDHCPRelayTestCase extends TestCase {
         # Ensure we can enable the DHCPRelay
         $this->assert_does_not_throw(
             callable: function () {
-                $dhcp_relay = new DHCPRelay(enable: true, server: ["1.2.3.4"]);
+                $dhcp_relay = new DHCPRelay(enable: true, server: ['1.2.3.4']);
                 $dhcp_relay->update();
             },
         );

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsDHCPRelayTestCase.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsDHCPRelayTestCase.inc
@@ -32,7 +32,7 @@ class APIModelsDHCPRelayTestCase extends TestCase {
         # Ensure we can enable the DHCPRelay
         $this->assert_does_not_throw(
             callable: function () {
-                $dhcp_relay = new DHCPRelay(enable: true);
+                $dhcp_relay = new DHCPRelay(enable: true, server: ["1.2.3.4"]);
                 $dhcp_relay->update();
             },
         );

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsDHCPRelayTestCase.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsDHCPRelayTestCase.inc
@@ -1,0 +1,108 @@
+<?php
+
+namespace RESTAPI\Tests;
+
+use RESTAPI\Auth\BasicAuth;
+use RESTAPI\Core\Command;
+use RESTAPI\Core\TestCase;
+use RESTAPI\Models\DHCPRelay;
+use RESTAPI\Models\DHCPServer;
+
+class APIModelsDHCPRelayTestCase extends TestCase {
+    /**
+     * Disables all running DHCPServers.
+     */
+    public function disable_dhcp_servers(bool $apply = false): void {
+        foreach (DHCPServer::query(enable: true)->model_objects as $dhcp_server) {
+            $dhcp_server->enable->value = false;
+            $dhcp_server->update();
+        }
+        if ($apply) {
+            (new DHCPServer())->apply();
+        }
+    }
+
+    /**
+     * Checks that the DHCPRelay cannot be enabled if any DHCPServer is already enabled.
+     */
+    public function test_dhcp_relay_cannot_enable_if_dhcp_server_enabled(): void {
+        # Disable all running DHCPServers
+        $this->disable_dhcp_servers();
+
+        # Ensure we can enable the DHCPRelay
+        $this->assert_does_not_throw(
+            callable: function () {
+                $dhcp_relay = new DHCPRelay(enable: true);
+                $dhcp_relay->update();
+            },
+        );
+
+        # Disable the DHCPRelay
+        $dhcp_relay = new DHCPRelay(enable: false);
+        $dhcp_relay->update();
+
+        # Enable a DHCPServer
+        $dhcp_server = new DHCPServer(id: 'lan', enable: true);
+        $dhcp_server->update();
+
+        # Ensure we cannot enable the DHCPRelay
+        $this->assert_throws_response(
+            response_id: 'DHCP_RELAY_CANNOT_BE_ENABLED_WHILE_DHCP_SERVER_IS_ENABLED',
+            code: 409,
+            callable: function () use ($dhcp_relay) {
+                $dhcp_relay = new DHCPRelay(enable: true);
+                $dhcp_relay->update();
+            },
+        );
+    }
+
+    /**
+     * Checks that the to_internal() method correctly appends the '_vip' prefix to the 'carpstatusvip' field.
+     */
+    public function test_dhcp_relay_to_internal_carpstatusvip(): void {
+        $dhcp_relay = new DHCPRelay(carpstatusvip: 'examplecarpvip');
+        $this->assert_equals($dhcp_relay->to_internal()['carpstatusvip'], '_vipexamplecarpvip');
+    }
+
+    /**
+     * Checks that the from_internal_carpstatusvip() method correctly removes the '_vip' prefix from the 'carpstatusvip'
+     * field when the value is loaded from the internal data.
+     */
+    public function test_dhcp_relay_from_internal_carpstatusvip(): void {
+        $dhcp_relay = new DHCPRelay();
+        $this->assert_equals($dhcp_relay->from_internal_carpstatusvip('_vipexamplecarpvip'), 'examplecarpvip');
+    }
+
+    /**
+     * Checks that the DHCP relay service is running after enabling and disabled after disabling the DHCPRelay.
+     */
+    public function test_dhcp_relay_service_running(): void {
+        # Disable all running DHCPServers
+        $this->disable_dhcp_servers(apply: true);
+
+        # Ensure the DHCPRelay is enabled
+        $dhcp_relay = new DHCPRelay(enable: true, server: ['1.2.3.4']);
+        $dhcp_relay->update();
+
+        # Ensure the DHCP relay service is running with the correct arguments
+        $dhcrelay_process = new Command('ps aux | grep dhcrelay');
+        $lan_if = $this->env['PFREST_LAN_IF'];
+        $wan_if = $this->env['PFREST_WAN_IF'];
+        $this->assert_str_contains(
+            $dhcrelay_process->output,
+            "/usr/local/sbin/dhcrelay -id $lan_if -iu $wan_if -a -m replace 1.2.3.4",
+        );
+
+        # Disable the DHCPRelay
+        $dhcp_relay = new DHCPRelay(enable: false);
+        $dhcp_relay->update();
+
+        # Ensure the DHCP relay service is not running
+        $dhcrelay_pid = new Command('pgrep dhcrelay');
+        $this->assert_equals($dhcrelay_pid->result_code, 1);
+
+        # Re-enable the DHCPServer on LAN
+        $dhcp_server = new DHCPServer(id: 'lan', enable: true);
+        $dhcp_server->update(apply: true);
+    }
+}

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsDHCPRelayTestCase.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsDHCPRelayTestCase.inc
@@ -18,7 +18,7 @@ class APIModelsDHCPRelayTestCase extends TestCase {
             $dhcp_server->update();
         }
         if ($apply) {
-            (new DHCPServer())->apply();
+            (new DHCPServer(async: false))->apply();
         }
     }
 
@@ -81,7 +81,7 @@ class APIModelsDHCPRelayTestCase extends TestCase {
         $this->disable_dhcp_servers(apply: true);
 
         # Ensure the DHCPRelay is enabled
-        $dhcp_relay = new DHCPRelay(enable: true, server: ['1.2.3.4']);
+        $dhcp_relay = new DHCPRelay(enable: true, interface: ["lan"], server: ['1.2.3.4']);
         $dhcp_relay->update();
 
         # Ensure the DHCP relay service is running with the correct arguments
@@ -90,7 +90,7 @@ class APIModelsDHCPRelayTestCase extends TestCase {
         $wan_if = $this->env['PFREST_WAN_IF'];
         $this->assert_str_contains(
             $dhcrelay_process->output,
-            "/usr/local/sbin/dhcrelay -id $lan_if -iu $wan_if -a -m replace 1.2.3.4",
+            "/usr/local/sbin/dhcrelay -id $lan_if -iu $wan_if 1.2.3.4",
         );
 
         # Disable the DHCPRelay

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsDHCPServerTestCase.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsDHCPServerTestCase.inc
@@ -43,7 +43,7 @@ class APIModelsDHCPServerTestCase extends TestCase {
                 $dhcp_server = new DHCPServer(id: 'lan', async: false);
 
                 # Temporarily change the `lan` interface to use dhcp IPv4
-                Model::set_config('dhcrelay/0/interface', 'lan');
+                Model::set_config('dhcrelay/interface', 'lan');
 
                 # Try to enable the DHCP server
                 $dhcp_server->validate_enable(enable: true);

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsDHCPServerTestCase.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsDHCPServerTestCase.inc
@@ -43,7 +43,7 @@ class APIModelsDHCPServerTestCase extends TestCase {
                 $dhcp_server = new DHCPServer(id: 'lan', async: false);
 
                 # Temporarily change the `lan` interface to use dhcp IPv4
-                Model::set_config('dhcrelay/enable', "");
+                Model::set_config('dhcrelay/enable', '');
 
                 # Try to enable the DHCP server
                 $dhcp_server->validate_enable(enable: true);

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsDHCPServerTestCase.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsDHCPServerTestCase.inc
@@ -34,7 +34,7 @@ class APIModelsDHCPServerTestCase extends TestCase {
     /**
      * Ensures that a DHCP server cannot be enabled on an interface is already running a DHCP relay.
      */
-    public function test_cannot_enable_dhcp_server_with_relay_running() {
+    public function test_cannot_enable_dhcp_server_with_relay_running(): void {
         $this->assert_throws_response(
             response_id: 'DHCP_SERVER_CANNOT_BE_ENABLED_WITH_DHCP_RELAY',
             code: 400,
@@ -43,7 +43,7 @@ class APIModelsDHCPServerTestCase extends TestCase {
                 $dhcp_server = new DHCPServer(id: 'lan', async: false);
 
                 # Temporarily change the `lan` interface to use dhcp IPv4
-                Model::set_config('dhcrelay/interface', 'lan');
+                Model::set_config('dhcrelay/enable', "");
 
                 # Try to enable the DHCP server
                 $dhcp_server->validate_enable(enable: true);

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsHAProxyBackendTestCase.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsHAProxyBackendTestCase.inc
@@ -139,4 +139,18 @@ class APIModelsHAProxyBackendTestCase extends TestCase {
         $backend->delete();
         $this->assert_is_false(HAProxyBackend::query(id: $backend->id)->exists());
     }
+
+    /**
+     * Ensure that the HAProxyBackend::$advanced_backend property is base64 encoded internally.
+     */
+    public function test_advanced_backend_is_base64(): void {
+        # Ensure the advanced_backend property is base64 encoded when converted to internal config value
+        $backend = new HAProxyBackend(advanced_backend: 'test');
+        $this->assert_equals($backend->advanced_backend->to_internal(), base64_encode('test'));
+
+        # Ensure the advanced_backend property is base64 decoded when converted from internal config value
+        $backend = new HAProxyBackend();
+        $backend->advanced_backend->from_internal(base64_encode('test'));
+        $this->assert_equals($backend->advanced_backend->value, 'test');
+    }
 }

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsOpenVPNClientTestCase.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsOpenVPNClientTestCase.inc
@@ -42,6 +42,7 @@ class APIModelsOpenVPNClientTestCase extends TestCase {
             'protocol' => 'UDP4',
             'interface' => 'wan',
             'server_addr' => 'example.com',
+            'server_port' => '1194',
             'tls' => $this->tls_key,
             'tls_type' => 'auth',
             'dh_length' => '2048',

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsServiceTestCase.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsServiceTestCase.inc
@@ -23,36 +23,11 @@ class APIModelsServiceTestCase extends TestCase {
     }
 
     /**
-     * Checks that the `get_service_name_choices()` method correctly identifies all available service names.
-     */
-    public function test_get_service_name_choices(): void {
-        # Ensure expected services are found in the method's response
-        $expected_services = ['unbound', 'ntpd', 'syslogd', 'dhcpd', 'dpinger', 'sshd'];
-
-        # Loop through each expected service and ensure it is found
-        foreach ($expected_services as $service) {
-            $this->assert_is_true(in_array($service, (new Service())->get_service_name_choices()));
-        }
-    }
-
-    /**
-     * Checks that the `get_id_by_name()` correctly obtains the ID of the Service object with a specific `name`
-     */
-    public function test_get_id_by_name(): void {
-        # Create a Service object to test with
-        $test_service = new Service();
-
-        # Obtain the ID of the `sshd` service and ensure the correct ID was given
-        $sshd_id = $test_service->get_id_by_name('sshd');
-        $this->assert_equals($sshd_id, $test_service->query(['name' => 'sshd'])->first()->id);
-    }
-
-    /**
      * Checks that a Service can be stopped, started and restarted.
      */
     public function test_can_perform_service_actions(): void {
-        # Define a Service to test with
-        $test_service = new Service(data: ['name' => 'ntpd']);
+        # Obtain a Service to test with
+        $test_service = Service::query(name: "ntpd")->first();
 
         # Ensure the service can be stopped
         $test_service->action->value = 'stop';

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsServiceTestCase.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsServiceTestCase.inc
@@ -27,7 +27,7 @@ class APIModelsServiceTestCase extends TestCase {
      */
     public function test_can_perform_service_actions(): void {
         # Obtain a Service to test with
-        $test_service = Service::query(name: "ntpd")->first();
+        $test_service = Service::query(name: 'ntpd')->first();
 
         # Ensure the service can be stopped
         $test_service->action->value = 'stop';

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsWireGuardSettingsTestCase.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsWireGuardSettingsTestCase.inc
@@ -19,12 +19,12 @@ class APIModelsWireGuardSettingsTestCase extends TestCase {
         # Enable WireGuard and ensure the service is running
         $wg = new WireGuardSettings(enable: true, async: false);
         $wg->update(apply: true);
-        $this->assert_is_true(Service::query(name: 'wireguard', status: true)->exists());
+        $this->assert_is_true(is_service_running('wireguard'));
 
         # Disable WireGuard and ensure the service is stopped
         $wg->enable->value = false;
         $wg->update(apply: true);
-        $this->assert_is_true(Service::query(name: 'wireguard', status: false)->exists());
+        $this->assert_is_false(is_service_running('wireguard'));
     }
 
     /**


### PR DESCRIPTION
### New

- Adds /api/v2/services/dhcp_relay endpoint for configuring the DHCP Relay service (#121)
- Adds support for SSL offloading in /api/v2/services/haproxy/frontend endpoints (#661)
- Adds endpoints for /api/v2/services/haproxy/frontend/certificate (#661)

### Fixes

- Fixes an issue where some services' status was not accurately obtained (#634)
- Fixes an issue where the WireGuard service's enabled status was not always represented correctly
- Fixes an issue where the /api/v2/services/dhcp_server endpoints could not be used if any DHCP Relay configuration is currently in the config
- Fixes an issue where /api/v2/services/dhcp_server did not accurately determine if a DHCP Relay was running

### Changes

- Makes /api/v2/services/haproxy/backend's `advanced_backend` field a Base64Field instead of plain StringField (#640) _This may be a breaking change for existing integrations!_
- Makes /api/v2/services/bind/zone's `refresh`, `retry`, `expire` and `minimum` fields StringField's instead of IntegerFields (#653) _This may be a breaking change for existing integrations!_
- POST requests to /api/v2/status/service now requires the `id` field to select the targeted service instead of `name` (#634, #635)
