### PR TITLE
v2.5.3 Features

### DIFF
--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/PortForward.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/PortForward.inc
@@ -65,7 +65,7 @@ class PortForward extends Model {
         );
         $this->protocol = new StringField(
             required: true,
-            choices: ['tcp', 'udp', 'tcp/udp', 'icmp', 'esp', 'ah', 'gre', 'ipv6', 'igmp', 'pim', 'ospf'],
+            choices: ['any', 'tcp', 'udp', 'tcp/udp', 'icmp', 'esp', 'ah', 'gre', 'ipv6', 'igmp', 'pim', 'ospf'],
             help_text: 'The IP/transport protocol this port forward rule should match.',
         );
         $this->source = new FilterAddressField(

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/PortForward.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/PortForward.inc
@@ -11,6 +11,7 @@ use RESTAPI\Fields\FilterAddressField;
 use RESTAPI\Fields\ForeignModelField;
 use RESTAPI\Fields\InterfaceField;
 use RESTAPI\Fields\PortField;
+use RESTAPI\Fields\SpecialNetworkField;
 use RESTAPI\Fields\StringField;
 use RESTAPI\Fields\UnixTimeField;
 use RESTAPI\Responses\ServerError;
@@ -27,7 +28,7 @@ class PortForward extends Model {
     public PortField $source_port;
     public FilterAddressField $destination;
     public PortField $destination_port;
-    public FilterAddressField $target;
+    public SpecialNetworkField $target;
     public PortField $local_port;
     public BooleanField $disabled;
     public BooleanField $nordr;
@@ -96,7 +97,7 @@ class PortForward extends Model {
             conditions: ['protocol' => ['tcp', 'udp', 'tcp/udp']],
             help_text: 'The destination port this port forward rule applies to. Set to `null` to allow any destination port.',
         );
-        $this->target = new FilterAddressField(
+        $this->target = new SpecialNetworkField(
             required: true,
             allow_ipaddr: true,
             allow_subnet: false,
@@ -104,8 +105,6 @@ class PortForward extends Model {
             allow_interface: false,
             allow_interface_ip: true,
             allow_interface_groups: false,
-            allow_any: false,
-            allow_invert: false,
             allow_self: false,
             allow_l2tp: false,
             allow_pppoe: false,

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/PortForward.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/PortForward.inc
@@ -27,7 +27,7 @@ class PortForward extends Model {
     public PortField $source_port;
     public FilterAddressField $destination;
     public PortField $destination_port;
-    public StringField $target;
+    public FilterAddressField $target;
     public PortField $local_port;
     public BooleanField $disabled;
     public BooleanField $nordr;
@@ -96,9 +96,19 @@ class PortForward extends Model {
             conditions: ['protocol' => ['tcp', 'udp', 'tcp/udp']],
             help_text: 'The destination port this port forward rule applies to. Set to `null` to allow any destination port.',
         );
-        $this->target = new StringField(
+        $this->target = new FilterAddressField(
             required: true,
-            validators: [new IPAddressValidator(allow_ipv4: true, allow_ipv6: true, allow_alias: true)],
+            allow_ipaddr: true,
+            allow_subnet: false,
+            allow_alias: true,
+            allow_interface: false,
+            allow_interface_ip: true,
+            allow_interface_groups: false,
+            allow_any: false,
+            allow_invert: false,
+            allow_self: false,
+            allow_l2tp: false,
+            allow_pppoe: false,
             help_text: 'The IP address or alias of the internal host to forward matching traffic to.',
         );
         $this->local_port = new PortField(

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsPortForwardTestCase.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsPortForwardTestCase.inc
@@ -235,12 +235,12 @@ class APIModelsPortForwardTestCase extends TestCase {
      */
     public function test_target_validation(): void {
         # Create an alias to test with
-        $alias = new FirewallAlias(name: "testalias", type:"host");
+        $alias = new FirewallAlias(name: 'testalias', type: 'host');
         $alias->create();
 
         # Set values we expect to be allowed vs disallowed
-        $allowed_values = ["1.2.3.4", "wan:ip", "testalias"];
-        $disallowed_values = ["example.com", "wan", "self", "l2tp", "1.2.3.4/24"];
+        $allowed_values = ['1.2.3.4', 'wan:ip', 'testalias'];
+        $disallowed_values = ['example.com', 'wan', 'self', 'l2tp', '1.2.3.4/24'];
 
         # Check each allowed value and ensure it does not throw an exception during validation
         foreach ($allowed_values as $value) {
@@ -265,7 +265,7 @@ class APIModelsPortForwardTestCase extends TestCase {
         # Check each disallowed value and ensure it throws an exception during validation
         foreach ($disallowed_values as $value) {
             $this->assert_throws(
-                exceptions: ["ValidationError"],
+                exceptions: ['ValidationError'],
                 callable: function () use ($value) {
                     $port_forward = new PortForward(
                         data: [
@@ -279,7 +279,7 @@ class APIModelsPortForwardTestCase extends TestCase {
                         ],
                     );
                     $port_forward->validate();
-                }
+                },
             );
         }
     }

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsPortForwardTestCase.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsPortForwardTestCase.inc
@@ -3,8 +3,10 @@
 namespace RESTAPI\Tests;
 
 use RESTAPI\Core\TestCase;
+use RESTAPI\Models\FirewallAlias;
 use RESTAPI\Models\FirewallRule;
 use RESTAPI\Models\PortForward;
+use RESTAPI\Responses\ValidationError;
 
 class APIModelsPortForwardTestCase extends TestCase {
     /**
@@ -226,5 +228,59 @@ class APIModelsPortForwardTestCase extends TestCase {
         $port_forward->delete();
         $rule_q = FirewallRule::query(associated_rule_id: $port_forward->associated_rule_id->value);
         $this->assert_is_false($rule_q->exists());
+    }
+
+    /**
+     * Ensures the target field accepts IP addresses, aliases and interface IPs
+     */
+    public function test_target_validation(): void {
+        # Create an alias to test with
+        $alias = new FirewallAlias(name: "testalias", type:"host");
+        $alias->create();
+
+        # Set values we expect to be allowed vs disallowed
+        $allowed_values = ["1.2.3.4", "wan:ip", "testalias"];
+        $disallowed_values = ["example.com", "wan", "self", "l2tp", "1.2.3.4/24"];
+
+        # Check each allowed value and ensure it does not throw an exception during validation
+        foreach ($allowed_values as $value) {
+            $this->assert_does_not_throw(
+                callable: function () use ($value) {
+                    $port_forward = new PortForward(
+                        data: [
+                            'interface' => 'wan',
+                            'protocol' => 'tcp',
+                            'source' => 'any',
+                            'destination' => 'wan:ip',
+                            'destination_port' => '8443',
+                            'target' => $value,
+                            'local_port' => '4443',
+                        ],
+                    );
+                    $port_forward->validate();
+                },
+            );
+        }
+
+        # Check each disallowed value and ensure it throws an exception during validation
+        foreach ($disallowed_values as $value) {
+            $this->assert_throws(
+                exceptions: ["ValidationError"],
+                callable: function () use ($value) {
+                    $port_forward = new PortForward(
+                        data: [
+                            'interface' => 'wan',
+                            'protocol' => 'tcp',
+                            'source' => 'any',
+                            'destination' => 'wan:ip',
+                            'destination_port' => '8443',
+                            'target' => $value,
+                            'local_port' => '4443',
+                        ],
+                    );
+                    $port_forward->validate();
+                }
+            );
+        }
     }
 }

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsPortForwardTestCase.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsPortForwardTestCase.inc
@@ -265,7 +265,7 @@ class APIModelsPortForwardTestCase extends TestCase {
         # Check each disallowed value and ensure it throws an exception during validation
         foreach ($disallowed_values as $value) {
             $this->assert_throws(
-                exceptions: ['ValidationError'],
+                exceptions: ['RESTAPI\Responses\ValidationError'],
                 callable: function () use ($value) {
                     $port_forward = new PortForward(
                         data: [


### PR DESCRIPTION
### New

- Adds `any` to available `protocol` choices in PortForward (#721)
- Allows `target` to be set to an interface IP accessor in PortForward (#721)