### PR TITLE
Support haproxy devel package

### DIFF
--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Core/Dispatcher.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Core/Dispatcher.inc
@@ -121,12 +121,30 @@ class Dispatcher {
     private function check_required_packages(): void {
         # Loop through each required package and ensure it is present on the system.
         foreach ($this->required_packages as $pkg) {
-            # Return an error if the package is not installed
-            if (!is_pkg_installed($pkg)) {
-                throw new FailedDependencyError(
-                    message: "The requested action requires the '$pkg' package but it is not installed.",
-                    response_id: 'DISPATCHER_MISSING_REQUIRED_PACKAGE',
-                );
+            # Handle array of alternative packages (any one must be installed)
+            if (is_array($pkg)) {
+                $any_installed = false;
+                foreach ($pkg as $alternative_pkg) {
+                    if (is_pkg_installed($alternative_pkg)) {
+                        $any_installed = true;
+                        break;
+                    }
+                }
+                if (!$any_installed) {
+                    $pkg_list = implode("' or '", $pkg);
+                    throw new FailedDependencyError(
+                        message: "The requested action requires one of the following packages: '$pkg_list', but none are installed.",
+                        response_id: 'DISPATCHER_MISSING_REQUIRED_PACKAGE',
+                    );
+                }
+            } else {
+                # Single package requirement
+                if (!is_pkg_installed($pkg)) {
+                    throw new FailedDependencyError(
+                        message: "The requested action requires the '$pkg' package but it is not installed.",
+                        response_id: 'DISPATCHER_MISSING_REQUIRED_PACKAGE',
+                    );
+                }
             }
         }
 

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Core/Model.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Core/Model.inc
@@ -1624,12 +1624,30 @@ class Model {
     private function check_packages() {
         # Loop through each required package and ensure it is present on the system.
         foreach ($this->packages as $pkg) {
-            # Return an error if the package is not installed
-            if (!is_pkg_installed($pkg)) {
-                throw new NotFoundError(
-                    message: "The requested action requires the '$pkg' package but it is not installed.",
-                    response_id: 'MODEL_MISSING_REQUIRED_PACKAGE',
-                );
+            # Handle array of alternative packages (any one must be installed)
+            if (is_array($pkg)) {
+                $any_installed = false;
+                foreach ($pkg as $alternative_pkg) {
+                    if (is_pkg_installed($alternative_pkg)) {
+                        $any_installed = true;
+                        break;
+                    }
+                }
+                if (!$any_installed) {
+                    $pkg_list = implode("' or '", $pkg);
+                    throw new NotFoundError(
+                        message: "The requested action requires one of the following packages: '$pkg_list', but none are installed.",
+                        response_id: 'MODEL_MISSING_REQUIRED_PACKAGE',
+                    );
+                }
+            } else {
+                # Single package requirement
+                if (!is_pkg_installed($pkg)) {
+                    throw new NotFoundError(
+                        message: "The requested action requires the '$pkg' package but it is not installed.",
+                        response_id: 'MODEL_MISSING_REQUIRED_PACKAGE',
+                    );
+                }
             }
         }
 

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Core/TestCase.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Core/TestCase.inc
@@ -99,7 +99,18 @@ class TestCase {
      */
     public function install_packages(): void {
         foreach ($this->required_packages as $package) {
-            new Command("pkg install -y $package");
+            # Handle array of alternative packages (try installing any one)
+            if (is_array($package)) {
+                foreach ($package as $alternative_pkg) {
+                    $result = new Command("pkg install -y $alternative_pkg");
+                    if ($result->result_code === 0) {
+                        break; # Successfully installed, move to next package group
+                    }
+                }
+            } else {
+                # Single package requirement
+                new Command("pkg install -y $package");
+            }
             Model::reload_config(true);
         }
     }

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Dispatchers/HAProxyApplyDispatcher.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Dispatchers/HAProxyApplyDispatcher.inc
@@ -10,7 +10,7 @@ use RESTAPI\Core\Dispatcher;
  * Defines a Dispatcher for applying changes to the HAProxy settings.
  */
 class HAProxyApplyDispatcher extends Dispatcher {
-    protected array $required_packages = ['pfSense-pkg-haproxy'];
+    protected array $required_packages = [['pfSense-pkg-haproxy', 'pfSense-pkg-haproxy-devel']];
     protected array $package_includes = ['haproxy/haproxy.inc', 'haproxy/haproxy_utils.inc'];
 
     /**

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyApply.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyApply.inc
@@ -17,7 +17,7 @@ class HAProxyApply extends Model {
         $this->internal_callable = 'get_applied_status';
         $this->always_apply = true;
         $this->many = false;
-        $this->packages = ['pfSense-pkg-haproxy'];
+        $this->packages = [['pfSense-pkg-haproxy', 'pfSense-pkg-haproxy-devel']];
         $this->package_includes = ['haproxy/haproxy.inc', 'haproxy/haproxy_utils.inc'];
 
         # Set model fields

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyBackend.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyBackend.inc
@@ -80,7 +80,7 @@ class HAProxyBackend extends Model {
     public function __construct(mixed $id = null, mixed $parent_id = null, mixed $data = [], ...$options) {
         # Set model attributes
         $this->config_path = 'installedpackages/haproxy/ha_pools/item';
-        $this->packages = ['pfSense-pkg-haproxy'];
+        $this->packages = [['pfSense-pkg-haproxy', 'pfSense-pkg-haproxy-devel']];
         $this->package_includes = ['haproxy/haproxy.inc', 'haproxy/haproxy_utils.inc'];
         $this->many = true;
 

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyBackendACL.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyBackendACL.inc
@@ -23,7 +23,7 @@ class HAProxyBackendACL extends Model {
         $this->parent_model_class = 'HAProxyBackend';
         $this->config_path = 'a_acl/item';
         $this->verbose_name = 'HAProxy Backend Access Control List';
-        $this->packages = ['pfSense-pkg-haproxy'];
+        $this->packages = [['pfSense-pkg-haproxy', 'pfSense-pkg-haproxy-devel']];
         $this->package_includes = ['haproxy/haproxy.inc', 'haproxy/haproxy_utils.inc'];
         $this->many = true;
 

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyBackendAction.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyBackendAction.inc
@@ -30,7 +30,7 @@ class HAProxyBackendAction extends Model {
         # Set model attributes
         $this->parent_model_class = 'HAProxyBackend';
         $this->config_path = 'a_actionitems/item';
-        $this->packages = ['pfSense-pkg-haproxy'];
+        $this->packages = [['pfSense-pkg-haproxy', 'pfSense-pkg-haproxy-devel']];
         $this->package_includes = ['haproxy/haproxy.inc', 'haproxy/haproxy_utils.inc'];
         $this->many = true;
 

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyBackendErrorFile.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyBackendErrorFile.inc
@@ -18,7 +18,7 @@ class HAProxyBackendErrorFile extends Model {
         # Set model attributes
         $this->parent_model_class = 'HAProxyBackend';
         $this->config_path = 'errorfiles/item';
-        $this->packages = ['pfSense-pkg-haproxy'];
+        $this->packages = [['pfSense-pkg-haproxy', 'pfSense-pkg-haproxy-devel']];
         $this->package_includes = ['haproxy/haproxy.inc', 'haproxy/haproxy_utils.inc'];
         $this->many = true;
 

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyBackendServer.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyBackendServer.inc
@@ -29,7 +29,7 @@ class HAProxyBackendServer extends Model {
         # Set model attributes
         $this->parent_model_class = 'HAProxyBackend';
         $this->config_path = 'ha_servers/item';
-        $this->packages = ['pfSense-pkg-haproxy'];
+        $this->packages = [['pfSense-pkg-haproxy', 'pfSense-pkg-haproxy-devel']];
         $this->package_includes = ['haproxy/haproxy.inc', 'haproxy/haproxy_utils.inc'];
         $this->many = true;
 

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyDNSResolver.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyDNSResolver.inc
@@ -20,7 +20,7 @@ class HAProxyDNSResolver extends Model {
         # Set model attributes
         $this->parent_model_class = 'HAProxySettings';
         $this->config_path = 'dns_resolvers/item';
-        $this->packages = ['pfSense-pkg-haproxy'];
+        $this->packages = [['pfSense-pkg-haproxy', 'pfSense-pkg-haproxy-devel']];
         $this->package_includes = ['haproxy/haproxy.inc', 'haproxy/haproxy_utils.inc'];
         $this->many = true;
 

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyEmailMailer.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyEmailMailer.inc
@@ -20,7 +20,7 @@ class HAProxyEmailMailer extends Model {
         # Set model attributes
         $this->parent_model_class = 'HAProxySettings';
         $this->config_path = 'email_mailers/item';
-        $this->packages = ['pfSense-pkg-haproxy'];
+        $this->packages = [['pfSense-pkg-haproxy', 'pfSense-pkg-haproxy-devel']];
         $this->package_includes = ['haproxy/haproxy.inc', 'haproxy/haproxy_utils.inc'];
         $this->many = true;
 

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyFile.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyFile.inc
@@ -19,7 +19,7 @@ class HAProxyFile extends Model {
     public function __construct(mixed $id = null, mixed $parent_id = null, mixed $data = [], ...$options) {
         # Set model attributes
         $this->config_path = 'installedpackages/haproxy/files/item';
-        $this->packages = ['pfSense-pkg-haproxy'];
+        $this->packages = [['pfSense-pkg-haproxy', 'pfSense-pkg-haproxy-devel']];
         $this->package_includes = ['haproxy/haproxy.inc', 'haproxy/haproxy_utils.inc'];
         $this->many = true;
 

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyFrontend.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyFrontend.inc
@@ -40,7 +40,7 @@ class HAProxyFrontend extends Model {
     public function __construct(mixed $id = null, mixed $parent_id = null, mixed $data = [], ...$options) {
         # Set model attributes
         $this->config_path = 'installedpackages/haproxy/ha_backends/item';
-        $this->packages = ['pfSense-pkg-haproxy'];
+        $this->packages = [['pfSense-pkg-haproxy', 'pfSense-pkg-haproxy-devel']];
         $this->package_includes = ['haproxy/haproxy.inc', 'haproxy/haproxy_utils.inc'];
         $this->many = true;
 

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyFrontendACL.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyFrontendACL.inc
@@ -23,7 +23,7 @@ class HAProxyFrontendACL extends Model {
         $this->parent_model_class = 'HAProxyFrontend';
         $this->config_path = 'ha_acls/item';
         $this->verbose_name = 'HAProxy Frontend Access Control List';
-        $this->packages = ['pfSense-pkg-haproxy'];
+        $this->packages = [['pfSense-pkg-haproxy', 'pfSense-pkg-haproxy-devel']];
         $this->package_includes = ['haproxy/haproxy.inc', 'haproxy/haproxy_utils.inc'];
         $this->many = true;
 

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyFrontendAction.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyFrontendAction.inc
@@ -30,7 +30,7 @@ class HAProxyFrontendAction extends Model {
         # Set model attributes
         $this->parent_model_class = 'HAProxyFrontend';
         $this->config_path = 'a_actionitems/item';
-        $this->packages = ['pfSense-pkg-haproxy'];
+        $this->packages = [['pfSense-pkg-haproxy', 'pfSense-pkg-haproxy-devel']];
         $this->package_includes = ['haproxy/haproxy.inc', 'haproxy/haproxy_utils.inc'];
         $this->many = true;
 

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyFrontendAddress.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyFrontendAddress.inc
@@ -22,7 +22,7 @@ class HAProxyFrontendAddress extends Model {
         # Set model attributes
         $this->parent_model_class = 'HAProxyFrontend';
         $this->config_path = 'a_extaddr/item';
-        $this->packages = ['pfSense-pkg-haproxy'];
+        $this->packages = [['pfSense-pkg-haproxy', 'pfSense-pkg-haproxy-devel']];
         $this->package_includes = ['haproxy/haproxy.inc', 'haproxy/haproxy_utils.inc'];
         $this->many = true;
 

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyFrontendCertificate.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyFrontendCertificate.inc
@@ -17,7 +17,7 @@ class HAProxyFrontendCertificate extends Model {
         $this->parent_model_class = 'HAProxyFrontend';
         $this->config_path = 'ha_certificates/item';
         $this->verbose_name = 'HAProxy Frontend Certificates';
-        $this->packages = ['pfSense-pkg-haproxy'];
+        $this->packages = [['pfSense-pkg-haproxy', 'pfSense-pkg-haproxy-devel']];
         $this->package_includes = ['haproxy/haproxy.inc', 'haproxy/haproxy_utils.inc'];
         $this->many = true;
 

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyFrontendErrorFile.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxyFrontendErrorFile.inc
@@ -18,7 +18,7 @@ class HAProxyFrontendErrorFile extends Model {
         # Set model attributes
         $this->parent_model_class = 'HAProxyFrontend';
         $this->config_path = 'a_errorfiles/item';
-        $this->packages = ['pfSense-pkg-haproxy'];
+        $this->packages = [['pfSense-pkg-haproxy', 'pfSense-pkg-haproxy-devel']];
         $this->package_includes = ['haproxy/haproxy.inc', 'haproxy/haproxy_utils.inc'];
         $this->many = true;
 

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxySettings.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/HAProxySettings.inc
@@ -50,7 +50,7 @@ class HAProxySettings extends Model {
         # Set model attributes
         $this->config_path = 'installedpackages/haproxy';
         $this->many = false;
-        $this->packages = ['pfSense-pkg-haproxy'];
+        $this->packages = [['pfSense-pkg-haproxy', 'pfSense-pkg-haproxy-devel']];
         $this->package_includes = ['haproxy/haproxy.inc', 'haproxy/haproxy_utils.inc'];
 
         # Set model fields

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Schemas/OpenAPISchema.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Schemas/OpenAPISchema.inc
@@ -132,7 +132,18 @@ class OpenAPISchema extends Schema {
                 $endpoint_type = $endpoint->many ? 'Plural' : 'Singular';
                 $parent_model_class = $model->parent_model_class ?: 'None';
                 $priv_options_str = implode(', ', $endpoint->$privilege_property);
-                $required_packages_str = $model->packages ? implode(', ', $model->packages) : 'None';
+                # Handle nested package arrays for alternative package requirements
+                $packages_for_display = [];
+                if ($model->packages) {
+                    foreach ($model->packages as $pkg) {
+                        if (is_array($pkg)) {
+                            $packages_for_display[] = '(' . implode(' OR ', $pkg) . ')';
+                        } else {
+                            $packages_for_display[] = $pkg;
+                        }
+                    }
+                }
+                $required_packages_str = $packages_for_display ? implode(', ', $packages_for_display) : 'None';
                 $requires_auth_str = $endpoint->requires_auth ? 'Yes' : 'No';
                 $auth_method_str = implode(', ', $endpoint->auth_methods ?: $auth_classes_short);
                 $cache_class = $model->cache_class ?: 'None';

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsHAProxyApplyTestCase.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsHAProxyApplyTestCase.inc
@@ -7,7 +7,7 @@ use RESTAPI\Models\HAProxyApply;
 use RESTAPI\Models\HAProxySettings;
 
 class APIModelsHAProxyApplyTestCase extends TestCase {
-    public array $required_packages = ['pfSense-pkg-haproxy'];
+    public array $required_packages = [['pfSense-pkg-haproxy', 'pfSense-pkg-haproxy-devel']];
 
     /**
      * Checks that the `applied` field correctly indicates whether HAProxy has pending configuration chagnes.

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsHAProxyBackendTestCase.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsHAProxyBackendTestCase.inc
@@ -8,7 +8,7 @@ use RESTAPI\Models\HAProxyBackendACL;
 use RESTAPI\Models\HAProxyBackendAction;
 
 class APIModelsHAProxyBackendTestCase extends TestCase {
-    public array $required_packages = ['pfSense-pkg-haproxy'];
+    public array $required_packages = [['pfSense-pkg-haproxy', 'pfSense-pkg-haproxy-devel']];
 
     /**
      * Ensure that the HAProxyBackend model can be created, updated, and deleted.

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsHAProxyFrontendTestCase.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsHAProxyFrontendTestCase.inc
@@ -15,7 +15,7 @@ class APIModelsHAProxyFrontendTestCase extends TestCase {
     private HAProxyBackend $backend;
     private Certificate $main_crt;
     private Certificate $alt_crt;
-    public array $required_packages = ['pfSense-pkg-haproxy'];
+    public array $required_packages = [['pfSense-pkg-haproxy', 'pfSense-pkg-haproxy-devel']];
 
     /**
      * Setup the test case.

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsHAProxySettingsTestCase.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsHAProxySettingsTestCase.inc
@@ -7,7 +7,7 @@ use RESTAPI\Core\TestCase;
 use RESTAPI\Models\HAProxySettings;
 
 class APIModelsHAProxySettingsTestCase extends TestCase {
-    public array $required_packages = ['pfSense-pkg-haproxy'];
+    public array $required_packages = [['pfSense-pkg-haproxy', 'pfSense-pkg-haproxy-devel']];
 
     /**
      * Checks that the `enable` field correctly controls the HAProxy service's enablement.


### PR DESCRIPTION
Package dependency checks currently only accept 'pfSense-pkg-haproxy' and will fail when users have the devel package installed instead. This updates the logic to accept either the regular or devel HAProxy package

Also updates OpenAPI schema generation and test case package installation to handle the new nested array format