### PR TITLE
v2.5.4 Fixes

### DIFF
--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/FirewallAlias.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/FirewallAlias.inc
@@ -49,6 +49,7 @@ class FirewallAlias extends Model {
             default: [],
             allow_empty: true,
             many: true,
+            many_maximum: 0, // Do not enforce a maximum number of entries
             delimiter: ' ',
             help_text: "Sets the host, network or port entries for the alias. When `type` is set to `host`, each
                 entry must be a valid IP address or FQDN. When `type` is set to `network`, each entry must be a valid
@@ -59,6 +60,7 @@ class FirewallAlias extends Model {
             default: [],
             allow_empty: true,
             many: true,
+            many_maximum: 0, // Do not enforce a maximum number of entries
             delimiter: '||',
             help_text: "Sets descriptions for each alias `address`. Values must match the order of the `address` 
                 value it relates to. For example, the first value specified here is the description for the first

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Validators/LengthValidator.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Validators/LengthValidator.inc
@@ -44,7 +44,7 @@ class LengthValidator extends RESTAPI\Core\Validator {
                 );
             }
             # Throw an error if the string contains more characters than the specified maximum
-            if (strlen($value) > $this->maximum) {
+            if ($this->maximum and strlen($value) > $this->maximum) {
                 throw new ValidationError(
                     message: "Field '$field_name' exceeds the maximum character length of $this->maximum.",
                     response_id: 'LENGTH_VALIDATOR_MAXIMUM_CONSTRAINT',
@@ -61,7 +61,7 @@ class LengthValidator extends RESTAPI\Core\Validator {
                 );
             }
             # Throw an error if the array contains more array entries than the specified maximum
-            if (count($value) > $this->maximum) {
+            if ($this->maximum and count($value) > $this->maximum) {
                 throw new ValidationError(
                     message: "Field '$field_name' exceeds the maximum array length of $this->maximum.",
                     response_id: 'LENGTH_VALIDATOR_MAXIMUM_CONSTRAINT',


### PR DESCRIPTION
### New

- Adds easier method of excluding model fields from maximum length constraints

### Fixes

- Addresses an issue where FirewallAlias `address` and `detail` items were limited to a maximum of 128 items (#745)
