### PR TITLE
v2.6.2 Fixes

### DIFF
--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/VirtualIP.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/VirtualIP.inc
@@ -10,6 +10,7 @@ use RESTAPI\Fields\IntegerField;
 use RESTAPI\Fields\InterfaceField;
 use RESTAPI\Fields\StringField;
 use RESTAPI\Fields\UIDField;
+use RESTAPI\Responses\ConflictError;
 use RESTAPI\Responses\ValidationError;
 use RESTAPI\Validators\IPAddressValidator;
 use RESTAPI\Validators\UniqueFromForeignModelValidator;
@@ -89,7 +90,6 @@ class VirtualIP extends Model {
         );
         $this->vhid = new IntegerField(
             required: true,
-            unique: true,
             minimum: 1,
             maximum: 255,
             conditions: ['mode' => 'carp'],
@@ -176,6 +176,27 @@ class VirtualIP extends Model {
         }
 
         return $subnet_bits;
+    }
+
+    /**
+     * Adds extra validation to the vhid field.
+     * @param int $vhid The incoming `vhid` value to be validated.
+     * @return int The validated `vhid` value to be set.
+     * @throws ValidationError When the `vhid` value is already used by another CARP virtual IP on the same interface.
+     */
+    public function validate_vhid(int $vhid): int {
+        # Check for an existing CARP virtual IP with the same VHID on this interface
+        $vip_q = $this->query(id__except: $this->id, mode: 'carp', interface: $this->interface->value, vhid: $vhid);
+
+        # Ensure no other CARP virtual IP on this interface is using the same VHID
+        if ($vip_q->exists()) {
+            $vip = $vip_q->first();
+            throw new ConflictError(
+                message: "Virtual IP with ID '$vip->id' is already using VHID '$vhid' on interface '{$this->interface->value}'",
+                response_id: 'VIRTUALIP_VHID_ALREADY_IN_USE',
+            );
+        }
+        return $vhid;
     }
 
     /**

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsVirtualIPTestCase.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsVirtualIPTestCase.inc
@@ -242,4 +242,45 @@ class APIModelsVirtualIPTestCase extends TestCase {
         $carp_status->update();
         $carp_vip->delete(apply: true);
     }
+
+    public function test_carp_vhid_must_be_unique_per_interface(): void {
+        # Create a virtual IP to test with
+        $vip = new VirtualIP(
+            mode: 'carp',
+            interface: 'lan',
+            subnet: '127.1.2.3',
+            subnet_bits: 32,
+            password: 'testpasswd',
+            vhid: 5,
+        );
+        $vip->create();
+
+        # Ensure we can update the existing VIP with the same VHID without issue
+        $this->assert_does_not_throw(
+            callable: function () use ($vip) {
+                $vip->validate_vhid(vhid: 5);
+            },
+        );
+
+        # Ensure we cannot create a new VIP with the same VHID on the same interface
+        $this->assert_throws_response(
+            response_id: 'VIRTUALIP_VHID_ALREADY_IN_USE',
+            code: 409,
+            callable: function () {
+                $vip = new VirtualIP(mode: 'carp', interface: 'lan');
+                $vip->validate_vhid(vhid: 5);
+            },
+        );
+
+        # Ensure we can create a new VIP with the same VHID on a different interface
+        $this->assert_does_not_throw(
+            callable: function () {
+                $vip = new VirtualIP(mode: 'carp', interface: 'wan');
+                $vip->validate_vhid(vhid: 5);
+            },
+        );
+
+        # Clean up the VIP we created
+        $vip->delete();
+    }
 }


### PR DESCRIPTION
### Fixes

- Relaxes unique constraint of VirtualIP's `vhid` field to be unique per interface instance of globally unique. Fixes #754.