### PR TITLE
fix: don't assume new log_level setting was defaulted

### DIFF
--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Core/BaseTraits.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Core/BaseTraits.inc
@@ -53,7 +53,8 @@ trait BaseTraits {
 
         # If the log level has not been set yet, obtain it
         if (!isset(self::$__log_level)) {
-            self::$__log_level = constant(RESTAPISettings::get_pkg_config()['log_level']) ?? 4;
+            $log_lvl_cfg = RESTAPISettings::get_pkg_config()['log_level'] ?? 'LOG_WARNING';
+            self::$__log_level = constant($log_lvl_cfg);
         }
 
         # Do not log if the incoming level is higher than the configured log level


### PR DESCRIPTION
### Fixes

- Fixes an issue where `log_level` was not assigned its default as expected on some installs #829 #830 