### PR TITLE
chore(deps-dev): bump black version to 26.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jinja2~=3.1.6
 pylint~=4.0.5
-black~=26.1.0
+black~=26.3.1
 mkdocs~=1.6.1


### PR DESCRIPTION
- Bumps `black` from 26.1.0 to 26.3.1 to address CVE-2026-32274

> [!NOTE]
> This dependency has no functional or security impact on the package itself and is not bundled into installations. It is a development tool for formatting Python files which are only used as build tools.