### PR TITLE
Add dscp field to FirewallRule model

### DIFF
--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/FirewallRule.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Models/FirewallRule.inc
@@ -191,6 +191,13 @@ class FirewallRule extends Model {
             verbose_name: 'Log',
             help_text: 'Enable or disable logging of traffic that matches this rule.',
         );
+        $this->dscp = new StringField(
+            default: '',
+            choices: ['af11', 'af12', 'af13', 'af21', 'af22', 'af23', 'af31', 'af32', 'af33', 'af41', 'af42', 'af43', 'VA', 'EF', 'cs1', 'cs2', 'cs3', 'cs4', 'cs5', 'cs6', 'cs7', '0x01', '0x02', '0x04'],
+            allow_empty: true,
+            verbose_name: 'DSCP',
+            help_text: 'The DSCP value this firewall rule should match.',
+        );
         $this->tag = new StringField(
             default: '',
             allow_empty: true,

--- a/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsFirewallRuleTestCase.inc
+++ b/pfSense-pkg-RESTAPI/files/usr/local/pkg/RESTAPI/Tests/APIModelsFirewallRuleTestCase.inc
@@ -332,6 +332,33 @@ class APIModelsFirewallRuleTestCase extends TestCase {
     }
 
     /**
+     * Checks that the `dscp` field is properly set in the pfctl rule
+     */
+    public function test_dscp() {
+        # Create a firewall rule to test with
+        $rule = new FirewallRule(
+            data: [
+                'type' => 'pass',
+                'interface' => ['lan'],
+                'ipprotocol' => 'inet',
+                'protocol' => 'tcp',
+                'source' => 'any',
+                'destination' => 'any',
+                'dscp' => 'af11',
+            ],
+            async: false,
+        );
+        $rule->create(apply: true);
+
+        # Ensure the pfctl rule with this rule object's tracker matches the requested DSCP value
+        $pfctl_rules = file_get_contents('/tmp/rules.debug');
+        $this->assert_str_contains($pfctl_rules, "tos af11 ridentifier {$rule->tracker->value}");
+
+        # Delete the firewall rule
+        $rule->delete(apply: true);
+    }
+
+    /**
      * Checks that firewall rules with `log` enabled have the log flag set in pfctl
      */
     public function test_log() {


### PR DESCRIPTION
Fixes #918.

### What

Adds the `dscp` field to the `FirewallRule` model. The pfSense webConfigurator supports matching rules on a DSCP value (config field `dscp`, rendered as `tos <value>` in `rules.debug`), but the model didn't define it, so API clients submitting `dscp` had the value **silently discarded** — for policy-routing rules that means matching (and re-routing) far more traffic than intended.

### How

- `StringField` with pfSense's canonical choice list (`$firewall_rules_dscp_types` from `guiconfig.inc`), `allow_empty` for the unset case, placed with the other match-criteria fields.
- `test_dscp` in `APIModelsFirewallRuleTestCase`, following the existing `test_statetype` pattern: creates a rule with `dscp => af11`, asserts the generated ruleset contains `tos af11 ridentifier {tracker}`, deletes the rule.

### Testing

Beyond the included test case, the identical field definition was applied to a live pfSense 2.7.2 install (v2.4.0 package) and verified end-to-end:

- `POST /api/v2/firewall/rule` with `"dscp":"af11"` → 200 with `dscp` echoed in the response
- value persisted to config and returned on `GET`
- after `firewall/apply`, `pfctl -sr` shows the rule with `tos 0x28` (AF11) and `rules.debug` shows `tos af11`
- rules created without `dscp` are unaffected (field defaults to empty)